### PR TITLE
docs: change the documentation for using 'six.moves.collections_abc.Mapping' instead of 'dict' in 'client_options.from_dict()'

### DIFF
--- a/google/api_core/client_options.py
+++ b/google/api_core/client_options.py
@@ -33,7 +33,7 @@ You can pass a client options object to a client.
 
     client = ImageAnnotatorClient(client_options=options)
 
-You can also pass a dictionary.
+You can also pass a mapping object.
 
 .. code-block:: python
 
@@ -98,10 +98,10 @@ class ClientOptions(object):
 
 
 def from_dict(options):
-    """Construct a client options object from a dictionary.
+    """Construct a client options object from a mapping object.
 
     Args:
-        options (Dict[str, Any]): A dictionary with client options.
+        options (six.moves.collections_abc.Mapping): A mapping object with client options.
             See the docstring for ClientOptions for details on valid arguments.
     """
 


### PR DESCRIPTION
Closes #14 