### PR TITLE
fix(deps): require six >= 1.13.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ dependencies = [
     "google-auth >= 1.21.1, < 2.0dev",
     "requests >= 2.18.0, < 3.0.0dev",
     "setuptools >= 34.0.0",
-    "six >= 1.10.0",
+    "six >= 1.13.0",
     "pytz",
     'futures >= 3.2.0; python_version < "3.2"',
 ]


### PR DESCRIPTION
This library uses `collections_abc` which was added in six==1.13.0

https://github.com/benjaminp/six/blob/c0be8815d13df45b6ae471c4c436cce8c192245d/CHANGES#L30-L31