### PR TITLE
chore: tweak 'python_requires' to match supported Python versions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -71,13 +71,13 @@ def default(session):
         session.run(*pytest_args)
 
 
-@nox.session(python=["2.7", "3.5", "3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=["2.7", "3.6", "3.7", "3.8", "3.9"])
 def unit(session):
     """Run the unit test suite."""
     default(session)
 
 
-@nox.session(python=["2.7", "3.5", "3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=["2.7", "3.6", "3.7", "3.8", "3.9"])
 def unit_grpc_gcp(session):
     """Run the unit test suite with grpcio-gcp installed."""
 

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setuptools.setup(
     namespace_packages=namespaces,
     install_requires=dependencies,
     extras_require=extras,
-    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*",
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*",
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
Release-As: 1.24.0

See: https://github.com/googleapis/python-cloud-core/pull/55#pullrequestreview-550616742