### PR TITLE
fix: add operation name to x-goog-request-params

### DIFF
--- a/google/api_core/operations_v1/operations_client.py
+++ b/google/api_core/operations_v1/operations_client.py
@@ -137,7 +137,7 @@ class OperationsClient(object):
 
         # Add routing header
         metadata = metadata or []
-        metadata = metadata + [gapic_v1.routing_header.to_grpc_metadata({"name": name})]
+        metadata.append(gapic_v1.routing_header.to_grpc_metadata({"name": name}))
 
         return self._get_operation(request, retry=retry, timeout=timeout, metadata=metadata)
 
@@ -203,7 +203,7 @@ class OperationsClient(object):
 
         # Add routing header
         metadata = metadata or []
-        metadata = metadata + [gapic_v1.routing_header.to_grpc_metadata({"name": name})]
+        metadata.append(gapic_v1.routing_header.to_grpc_metadata({"name": name}))
 
         # Create the method used to fetch pages
         method = functools.partial(self._list_operations, retry=retry, timeout=timeout, metadata=metadata)
@@ -272,7 +272,7 @@ class OperationsClient(object):
 
         # Add routing header
         metadata = metadata or []
-        metadata = metadata + [gapic_v1.routing_header.to_grpc_metadata({"name": name})]
+        metadata.append(gapic_v1.routing_header.to_grpc_metadata({"name": name}))
 
         self._cancel_operation(request, retry=retry, timeout=timeout, metadata=metadata)
 
@@ -323,6 +323,6 @@ class OperationsClient(object):
 
         # Add routing header
         metadata = metadata or []
-        metadata = metadata + [gapic_v1.routing_header.to_grpc_metadata({"name": name})]
+        metadata.append(gapic_v1.routing_header.to_grpc_metadata({"name": name}))
 
         self._delete_operation(request, retry=retry, timeout=timeout, metadata=metadata)

--- a/google/api_core/operations_v1/operations_client.py
+++ b/google/api_core/operations_v1/operations_client.py
@@ -134,6 +134,11 @@ class OperationsClient(object):
                 subclass will be raised.
         """
         request = operations_pb2.GetOperationRequest(name=name)
+
+        # Add routing header
+        metadata = metadata or []
+        metadata = metadata + [gapic_v1.routing_header.to_grpc_metadata({"name": name})]
+
         return self._get_operation(request, retry=retry, timeout=timeout, metadata=metadata)
 
     def list_operations(
@@ -195,6 +200,10 @@ class OperationsClient(object):
         """
         # Create the request object.
         request = operations_pb2.ListOperationsRequest(name=name, filter=filter_)
+
+        # Add routing header
+        metadata = metadata or []
+        metadata = metadata + [gapic_v1.routing_header.to_grpc_metadata({"name": name})]
 
         # Create the method used to fetch pages
         method = functools.partial(self._list_operations, retry=retry, timeout=timeout, metadata=metadata)
@@ -260,6 +269,11 @@ class OperationsClient(object):
         """
         # Create the request object.
         request = operations_pb2.CancelOperationRequest(name=name)
+
+        # Add routing header
+        metadata = metadata or []
+        metadata = metadata + [gapic_v1.routing_header.to_grpc_metadata({"name": name})]
+
         self._cancel_operation(request, retry=retry, timeout=timeout, metadata=metadata)
 
     def delete_operation(
@@ -306,4 +320,9 @@ class OperationsClient(object):
         """
         # Create the request object.
         request = operations_pb2.DeleteOperationRequest(name=name)
+
+        # Add routing header
+        metadata = metadata or []
+        metadata = metadata + [gapic_v1.routing_header.to_grpc_metadata({"name": name})]
+
         self._delete_operation(request, retry=retry, timeout=timeout, metadata=metadata)

--- a/tests/unit/operations_v1/test_operations_client.py
+++ b/tests/unit/operations_v1/test_operations_client.py
@@ -24,9 +24,10 @@ def test_get_operation():
     client = operations_v1.OperationsClient(channel)
     channel.GetOperation.response = operations_pb2.Operation(name="meep")
 
-    response = client.get_operation("name", metadata=[("x-goog-request-params", "foo")])
+    response = client.get_operation("name", metadata=[("header", "foo")])
 
-    assert ("x-goog-request-params", "foo") in channel.GetOperation.calls[0].metadata
+    assert ("header", "foo") in channel.GetOperation.calls[0].metadata
+    assert ("x-goog-request-params", "name=name") in channel.GetOperation.calls[0].metadata
     assert len(channel.GetOperation.requests) == 1
     assert channel.GetOperation.requests[0].name == "name"
     assert response == channel.GetOperation.response
@@ -42,12 +43,13 @@ def test_list_operations():
     list_response = operations_pb2.ListOperationsResponse(operations=operations)
     channel.ListOperations.response = list_response
 
-    response = client.list_operations("name", "filter", metadata=[("x-goog-request-params", "foo")])
+    response = client.list_operations("name", "filter", metadata=[("header", "foo")])
 
     assert isinstance(response, page_iterator.Iterator)
     assert list(response) == operations
 
-    assert ("x-goog-request-params", "foo") in channel.ListOperations.calls[0].metadata
+    assert ("header", "foo") in channel.ListOperations.calls[0].metadata
+    assert ("x-goog-request-params", "name=name") in channel.ListOperations.calls[0].metadata
     assert len(channel.ListOperations.requests) == 1
     request = channel.ListOperations.requests[0]
     assert isinstance(request, operations_pb2.ListOperationsRequest)
@@ -60,9 +62,10 @@ def test_delete_operation():
     client = operations_v1.OperationsClient(channel)
     channel.DeleteOperation.response = empty_pb2.Empty()
 
-    client.delete_operation("name", metadata=[("x-goog-request-params", "foo")])
+    client.delete_operation("name", metadata=[("header", "foo")])
 
-    assert ("x-goog-request-params", "foo") in channel.DeleteOperation.calls[0].metadata
+    assert ("header", "foo") in channel.DeleteOperation.calls[0].metadata
+    assert ("x-goog-request-params", "name=name") in channel.DeleteOperation.calls[0].metadata
     assert len(channel.DeleteOperation.requests) == 1
     assert channel.DeleteOperation.requests[0].name == "name"
 
@@ -72,8 +75,9 @@ def test_cancel_operation():
     client = operations_v1.OperationsClient(channel)
     channel.CancelOperation.response = empty_pb2.Empty()
 
-    client.cancel_operation("name", metadata=[("x-goog-request-params", "foo")])
+    client.cancel_operation("name", metadata=[("header", "foo")])
 
-    assert ("x-goog-request-params", "foo") in channel.CancelOperation.calls[0].metadata
+    assert ("header", "foo") in channel.CancelOperation.calls[0].metadata
+    assert ("x-goog-request-params", "name=name") in channel.CancelOperation.calls[0].metadata
     assert len(channel.CancelOperation.requests) == 1
     assert channel.CancelOperation.requests[0].name == "name"


### PR DESCRIPTION
Add the routing header `x-goog-request-params` to operations client requests. Some APIs require that the header be passed on all requests.

Fixes https://github.com/googleapis/gapic-generator-python/issues/732