### PR TITLE
feat: allow default_host and default_scopes to be passed to create_channel

### DIFF
--- a/google/api_core/grpc_helpers.py
+++ b/google/api_core/grpc_helpers.py
@@ -216,27 +216,26 @@ def _create_composite_credentials(
         )
 
     if credentials_file:
+        # TODO: remove this try/except once google-auth >= 1.25.0 is required
         try:
             credentials, _ = google.auth.load_credentials_from_file(
                 credentials_file,
                 scopes=scopes,
                 default_scopes=default_scopes
             )
-        # google-auth < x.x.x does not have `default_scopes`
-        # TODO: remove this try/except once google-auth >= x.x.x is required
         except TypeError:
             credentials, _ = google.auth.load_credentials_from_file(
                 credentials_file,
                 scopes=scopes or default_scopes,
             )
     elif credentials:
+        # TODO: remove this try/except once google-auth >= 1.25.0 is required
         try:
             credentials = google.auth.credentials.with_scopes_if_required(
                 credentials,
                 scopes=scopes,
                 default_scopes=default_scopes
             )
-        # TODO: remove this try/except once google-auth >= 1.25.0 is required
         except TypeError:
             credentials = google.auth.credentials.with_scopes_if_required(
                 credentials,
@@ -244,10 +243,10 @@ def _create_composite_credentials(
             )
 
     else:
+        # TODO: remove this try/except once google-auth >= 1.25.0 is required
         try:
             credentials, _ = google.auth.default(scopes=scopes, default_scopes=default_scopes)
-        # TODO: remove this try/except once google-auth >= 1.25.0 is required
-        except TypeError: 
+        except TypeError:
             credentials, _ = google.auth.default(scopes=scopes or default_scopes)
 
     if quota_project_id and isinstance(credentials, google.auth.credentials.CredentialsWithQuotaProject):
@@ -262,7 +261,7 @@ def _create_composite_credentials(
         metadata_plugin = google.auth.transport.grpc.AuthMetadataPlugin(
             credentials, request, default_host=default_host,
         )
-    except:
+    except TypeError:
         metadata_plugin = google.auth.transport.grpc.AuthMetadataPlugin(
             credentials, request
         )

--- a/google/api_core/grpc_helpers.py
+++ b/google/api_core/grpc_helpers.py
@@ -183,7 +183,8 @@ def _create_composite_credentials(
         scopes=None,
         ssl_credentials=None,
         quota_project_id=None,
-        audience=None):
+        default_host=None
+    ):
     """Create the composite credentials for secure channels.
 
     Args:
@@ -202,7 +203,8 @@ def _create_composite_credentials(
         ssl_credentials (grpc.ChannelCredentials): Optional SSL channel
             credentials. This can be used to specify different certificates.
         quota_project_id (str): An optional project to use for billing and quota.
-        audience (str): The audience needed for authentication.
+        default_host (str): The default endpoint. e.g., "pubsub.googleapis.com"
+            
 
     Returns:
         grpc.ChannelCredentials: The composed channel credentials object.
@@ -232,7 +234,7 @@ def _create_composite_credentials(
 
     # Create the metadata plugin for inserting the authorization header.
     metadata_plugin = google.auth.transport.grpc.AuthMetadataPlugin(
-        credentials, request, audience=audience,
+        credentials, request, default_host=default_host,
     )
 
     # Create a set of grpc.CallCredentials using the metadata plugin.
@@ -255,7 +257,7 @@ def create_channel(
         credentials_file=None,
         quota_project_id=None,
         default_scopes=None,
-        audience=None,
+        default_host=None,
         **kwargs):
     """Create a secure channel with credentials.
 
@@ -276,11 +278,7 @@ def create_channel(
             :func:`google.auth.load_credentials_from_file`. This argument is
             mutually exclusive with credentials.
         quota_project_id (str): An optional project to use for billing and quota.
-        audience (str): The canonical audience that identfies the service
-            address. This is often the same as the targe. It will differ
-            for example of the target is pubsub.mtls.googleapis.com and the
-            audience is pubsub.googleapis.com
-        
+        default_host (str): The default endpoint. e.g., "pubsub.googleapis.com"
         kwargs: Additional key-word args passed to
             :func:`grpc_gcp.secure_channel` or :func:`grpc.secure_channel`.
 
@@ -298,7 +296,7 @@ def create_channel(
         scopes=scopes,
         ssl_credentials=ssl_credentials,
         quota_project_id=quota_project_id,
-        audience=audience,
+        default_host=default_host,
     )
 
     if HAS_GRPC_GCP:

--- a/google/api_core/grpc_helpers.py
+++ b/google/api_core/grpc_helpers.py
@@ -236,8 +236,7 @@ def _create_composite_credentials(
                 scopes=scopes,
                 default_scopes=default_scopes
             )
-        # google-auth < x.x.x does not have `default_scopes`
-        # TODO: remove this try/except once google-auth >= x.x.x is required
+        # TODO: remove this try/except once google-auth >= 1.25.0 is required
         except TypeError:
             credentials = google.auth.credentials.with_scopes_if_required(
                 credentials,
@@ -247,8 +246,7 @@ def _create_composite_credentials(
     else:
         try:
             credentials, _ = google.auth.default(scopes=scopes, default_scopes=default_scopes)
-        # google-auth < x.x.x does not have `default_scopes`
-        # TODO: remove this try/except once google-auth >= x.x.x is required
+        # TODO: remove this try/except once google-auth >= 1.25.0 is required
         except TypeError: 
             credentials, _ = google.auth.default(scopes=scopes or default_scopes)
 
@@ -259,8 +257,7 @@ def _create_composite_credentials(
 
     # Create the metadata plugin for inserting the authorization header.
 
-    # google-auth < x.x.x does not have `default_host`
-    # TODO: remove this try/except once google-auth >= x.x.x is required
+    # TODO: remove this try/except once google-auth >= 1.25.0 is required
     try:
         metadata_plugin = google.auth.transport.grpc.AuthMetadataPlugin(
             credentials, request, default_host=default_host,

--- a/google/api_core/grpc_helpers.py
+++ b/google/api_core/grpc_helpers.py
@@ -265,9 +265,6 @@ def create_channel(
         credentials (google.auth.credentials.Credentials): The credentials. If
             not specified, then this function will attempt to ascertain the
             credentials from the environment using :func:`google.auth.default`.
-        default_scopes (Sequence[str]): A optional list of scopes needed for this
-            service. These are only used when credentials are not specified and
-            are passed to :func:`google.auth.default`.
         scopes (Sequence[str]): A optional list of scopes needed for this
             service. These are only used when credentials are not specified and
             are passed to :func:`google.auth.default`.
@@ -277,6 +274,8 @@ def create_channel(
             :func:`google.auth.load_credentials_from_file`. This argument is
             mutually exclusive with credentials.
         quota_project_id (str): An optional project to use for billing and quota.
+        default_scopes (Sequence[str]): Default scopes passed by a Google client
+            library. Use 'scopes' for user-defined scopes.
         default_host (str): The default endpoint. e.g., "pubsub.googleapis.com".
         kwargs: Additional key-word args passed to
             :func:`grpc_gcp.secure_channel` or :func:`grpc.secure_channel`.

--- a/google/api_core/grpc_helpers.py
+++ b/google/api_core/grpc_helpers.py
@@ -203,8 +203,7 @@ def _create_composite_credentials(
         ssl_credentials (grpc.ChannelCredentials): Optional SSL channel
             credentials. This can be used to specify different certificates.
         quota_project_id (str): An optional project to use for billing and quota.
-        default_host (str): The default endpoint. e.g., "pubsub.googleapis.com"
-            
+        default_host (str): The default endpoint. e.g., "pubsub.googleapis.com".
 
     Returns:
         grpc.ChannelCredentials: The composed channel credentials object.
@@ -278,7 +277,7 @@ def create_channel(
             :func:`google.auth.load_credentials_from_file`. This argument is
             mutually exclusive with credentials.
         quota_project_id (str): An optional project to use for billing and quota.
-        default_host (str): The default endpoint. e.g., "pubsub.googleapis.com"
+        default_host (str): The default endpoint. e.g., "pubsub.googleapis.com".
         kwargs: Additional key-word args passed to
             :func:`grpc_gcp.secure_channel` or :func:`grpc.secure_channel`.
 

--- a/google/api_core/grpc_helpers.py
+++ b/google/api_core/grpc_helpers.py
@@ -183,8 +183,7 @@ def _create_composite_credentials(
         scopes=None,
         ssl_credentials=None,
         quota_project_id=None,
-        default_host=None
-    ):
+        default_host=None):
     """Create the composite credentials for secure channels.
 
     Args:
@@ -216,13 +215,18 @@ def _create_composite_credentials(
             "'credentials' and 'credentials_file' are mutually exclusive."
         )
 
-
     if credentials_file:
-        credentials, _ = google.auth.load_credentials_from_file(credentials_file,
-            scopes=scopes, default_scopes=default_scopes)
+        credentials, _ = google.auth.load_credentials_from_file(
+            credentials_file,
+            scopes=scopes,
+            default_scopes=default_scopes
+        )
     elif credentials:
-        credentials = google.auth.credentials.with_scopes_if_required(credentials,
-            scopes=scopes, default_scopes=default_scopes)
+        credentials = google.auth.credentials.with_scopes_if_required(
+            credentials,
+            scopes=scopes,
+            default_scopes=default_scopes
+        )
     else:
         credentials, _ = google.auth.default(scopes=scopes, default_scopes=default_scopes)
 

--- a/google/api_core/grpc_helpers_async.py
+++ b/google/api_core/grpc_helpers_async.py
@@ -213,6 +213,8 @@ def create_channel(
         ssl_credentials=None,
         credentials_file=None,
         quota_project_id=None,
+        default_scopes=None,
+        default_host=None,
         **kwargs):
     """Create an AsyncIO secure channel with credentials.
 
@@ -230,6 +232,9 @@ def create_channel(
             :func:`google.auth.load_credentials_from_file`. This argument is
             mutually exclusive with credentials.
         quota_project_id (str): An optional project to use for billing and quota.
+        default_scopes (Sequence[str]): Default scopes passed by a Google client
+            library. Use 'scopes' for user-defined scopes.
+        default_host (str): The default endpoint. e.g., "pubsub.googleapis.com".
         kwargs: Additional key-word args passed to :func:`aio.secure_channel`.
 
     Returns:
@@ -243,8 +248,10 @@ def create_channel(
         credentials=credentials,
         credentials_file=credentials_file,
         scopes=scopes,
+        default_scopes=default_scopes,
         ssl_credentials=ssl_credentials,
         quota_project_id=quota_project_id,
+        default_host=default_host
     )
 
     return aio.secure_channel(target, composite_credentials, **kwargs)

--- a/noxfile.py
+++ b/noxfile.py
@@ -50,9 +50,6 @@ def default(session):
     session.install("mock", "pytest", "pytest-cov", "grpcio >= 1.0.2")
     session.install("-e", ".", "-c", constraints_path)
 
-    # REMOVE ME: Temporarily install google-auth from a branch
-    session.install("-e", "git+https://github.com/googleapis/google-auth-library-python.git@self-signed-jwt#egg=google-auth")
-
     pytest_args = [
         "python",
         "-m",

--- a/noxfile.py
+++ b/noxfile.py
@@ -51,7 +51,7 @@ def default(session):
     session.install("-e", ".", "-c", constraints_path)
 
     # REMOVE ME: Temporarily install google-auth from a branch
-    # session.install("-e", "git+https://github.com/googleapis/google-auth-library-python.git@self-signed-jwt#egg=google-auth")
+    session.install("-e", "git+https://github.com/googleapis/google-auth-library-python.git@self-signed-jwt#egg=google-auth")
 
     pytest_args = [
         "python",

--- a/noxfile.py
+++ b/noxfile.py
@@ -50,6 +50,9 @@ def default(session):
     session.install("mock", "pytest", "pytest-cov", "grpcio >= 1.0.2")
     session.install("-e", ".", "-c", constraints_path)
 
+    # REMOVE ME: Temporarily install google-auth from a branch
+    session.install("-e", "git+https://github.com/googleapis/google-auth-library-python.git@self-signed-jwt#egg=google-auth")
+
     pytest_args = [
         "python",
         "-m",

--- a/noxfile.py
+++ b/noxfile.py
@@ -51,7 +51,7 @@ def default(session):
     session.install("-e", ".", "-c", constraints_path)
 
     # REMOVE ME: Temporarily install google-auth from a branch
-    session.install("-e", "git+https://github.com/googleapis/google-auth-library-python.git@self-signed-jwt#egg=google-auth")
+    # session.install("-e", "git+https://github.com/googleapis/google-auth-library-python.git@self-signed-jwt#egg=google-auth")
 
     pytest_args = [
         "python",

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ dependencies = [
     "google-auth >= 1.21.1, < 2.0dev",
     "requests >= 2.18.0, < 3.0.0dev",
     "setuptools >= 40.3.0",
+    "packaging >= 14.3",
     "six >= 1.13.0",
     "pytz",
     'futures >= 3.2.0; python_version < "3.2"',

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -10,6 +10,7 @@ protobuf==3.12.0
 google-auth==1.21.1
 requests==2.18.0
 setuptools==40.3.0
+packaging==14.3
 six==1.13.0
 grpcio==1.29.0
 grpcio-gcp==0.2.2

--- a/tests/asyncio/test_grpc_helpers_async.py
+++ b/tests/asyncio/test_grpc_helpers_async.py
@@ -273,7 +273,7 @@ def test_create_channel_implicit(grpc_secure_channel, default, composite_creds_c
     channel = grpc_helpers_async.create_channel(target)
 
     assert channel is grpc_secure_channel.return_value
-    default.assert_called_once_with(scopes=None)
+    default.assert_called_once_with(scopes=None, default_scopes=None)
     grpc_secure_channel.assert_called_once_with(target, composite_creds)
 
 
@@ -292,7 +292,7 @@ def test_create_channel_implicit_with_ssl_creds(
 
     grpc_helpers_async.create_channel(target, ssl_credentials=ssl_creds)
 
-    default.assert_called_once_with(scopes=None)
+    default.assert_called_once_with(scopes=None, default_scopes=None)
     composite_creds_call.assert_called_once_with(ssl_creds, mock.ANY)
     composite_creds = composite_creds_call.return_value
     grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -313,7 +313,7 @@ def test_create_channel_implicit_with_scopes(
     channel = grpc_helpers_async.create_channel(target, scopes=["one", "two"])
 
     assert channel is grpc_secure_channel.return_value
-    default.assert_called_once_with(scopes=["one", "two"])
+    default.assert_called_once_with(scopes=["one", "two"], default_scopes=None)
     grpc_secure_channel.assert_called_once_with(target, composite_creds)
 
 
@@ -339,7 +339,7 @@ def test_create_channel_explicit(grpc_secure_channel, auth_creds, composite_cred
 
     channel = grpc_helpers_async.create_channel(target, credentials=mock.sentinel.credentials)
 
-    auth_creds.assert_called_once_with(mock.sentinel.credentials, None)
+    auth_creds.assert_called_once_with(mock.sentinel.credentials, scopes=None, default_scopes=None)
     assert channel is grpc_secure_channel.return_value
     grpc_secure_channel.assert_called_once_with(target, composite_creds)
 
@@ -358,7 +358,7 @@ def test_create_channel_explicit_scoped(grpc_secure_channel, composite_creds_cal
         target, credentials=credentials, scopes=scopes
     )
 
-    credentials.with_scopes.assert_called_once_with(scopes)
+    credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
     assert channel is grpc_secure_channel.return_value
     grpc_secure_channel.assert_called_once_with(target, composite_creds)
 
@@ -396,7 +396,7 @@ def test_create_channnel_with_credentials_file(load_credentials_from_file, grpc_
         target, credentials_file=credentials_file
     )
 
-    google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=None)
+    google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=None, default_scopes=None)
     assert channel is grpc_secure_channel.return_value
     grpc_secure_channel.assert_called_once_with(target, composite_creds)
 
@@ -418,7 +418,7 @@ def test_create_channel_with_credentials_file_and_scopes(load_credentials_from_f
         target, credentials_file=credentials_file, scopes=scopes
     )
 
-    google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=scopes)
+    google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=scopes, default_scopes=None)
     assert channel is grpc_secure_channel.return_value
     grpc_secure_channel.assert_called_once_with(target, composite_creds)
 
@@ -434,7 +434,7 @@ def test_create_channel_without_grpc_gcp(grpc_secure_channel):
 
     grpc_helpers_async.create_channel(target, credentials=credentials, scopes=scopes)
     grpc_secure_channel.assert_called()
-    credentials.with_scopes.assert_called_once_with(scopes)
+    credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
 
 
 @pytest.mark.asyncio

--- a/tests/asyncio/test_grpc_helpers_async.py
+++ b/tests/asyncio/test_grpc_helpers_async.py
@@ -317,6 +317,25 @@ def test_create_channel_implicit_with_scopes(
     grpc_secure_channel.assert_called_once_with(target, composite_creds)
 
 
+@mock.patch("grpc.composite_channel_credentials")
+@mock.patch(
+    "google.auth.default",
+    return_value=(mock.sentinel.credentials, mock.sentinel.projet),
+)
+@mock.patch("grpc.experimental.aio.secure_channel")
+def test_create_channel_implicit_with_default_scopes(
+    grpc_secure_channel, default, composite_creds_call
+):
+    target = "example.com:443"
+    composite_creds = composite_creds_call.return_value
+
+    channel = grpc_helpers_async.create_channel(target, scopes=["one", "two"], default_scopes=["three", "four"])
+
+    assert channel is grpc_secure_channel.return_value
+    default.assert_called_once_with(scopes=["one", "two"], default_scopes=["three", "four"])
+    grpc_secure_channel.assert_called_once_with(target, composite_creds)
+
+
 def test_create_channel_explicit_with_duplicate_credentials():
     target = "example:443"
 
@@ -361,6 +380,27 @@ def test_create_channel_explicit_scoped(grpc_secure_channel, composite_creds_cal
     credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
     assert channel is grpc_secure_channel.return_value
     grpc_secure_channel.assert_called_once_with(target, composite_creds)
+
+
+@mock.patch("grpc.composite_channel_credentials")
+@mock.patch("grpc.experimental.aio.secure_channel")
+def test_create_channel_explicit_default_scopes(grpc_secure_channel, composite_creds_call):
+    target = "example.com:443"
+    scopes = ["1", "2"]
+    default_scopes = ["3", "4"]
+    composite_creds = composite_creds_call.return_value
+
+    credentials = mock.create_autospec(google.auth.credentials.Scoped, instance=True)
+    credentials.requires_scopes = True
+
+    channel = grpc_helpers_async.create_channel(
+        target, credentials=credentials, scopes=scopes, default_scopes=default_scopes
+    )
+
+    credentials.with_scopes.assert_called_once_with(scopes, default_scopes=default_scopes)
+    assert channel is grpc_secure_channel.return_value
+    grpc_secure_channel.assert_called_once_with(target, composite_creds)
+
 
 
 @mock.patch("grpc.composite_channel_credentials")
@@ -419,6 +459,29 @@ def test_create_channel_with_credentials_file_and_scopes(load_credentials_from_f
     )
 
     google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=scopes, default_scopes=None)
+    assert channel is grpc_secure_channel.return_value
+    grpc_secure_channel.assert_called_once_with(target, composite_creds)
+
+
+@mock.patch("grpc.composite_channel_credentials")
+@mock.patch("grpc.experimental.aio.secure_channel")
+@mock.patch(
+    "google.auth.load_credentials_from_file",
+    return_value=(mock.sentinel.credentials, mock.sentinel.project)
+)
+def test_create_channel_with_credentials_file_and_default_scopes(load_credentials_from_file, grpc_secure_channel, composite_creds_call):
+    target = "example.com:443"
+    scopes = ["1", "2"]
+    default_scopes = ["3", "4"]
+
+    credentials_file = "/path/to/credentials/file.json"
+    composite_creds = composite_creds_call.return_value
+
+    channel = grpc_helpers_async.create_channel(
+        target, credentials_file=credentials_file, scopes=scopes, default_scopes=default_scopes
+    )
+
+    google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=scopes, default_scopes=default_scopes)
     assert channel is grpc_secure_channel.return_value
     grpc_secure_channel.assert_called_once_with(target, composite_creds)
 

--- a/tests/asyncio/test_grpc_helpers_async.py
+++ b/tests/asyncio/test_grpc_helpers_async.py
@@ -15,6 +15,7 @@
 import grpc
 from grpc.experimental import aio
 import mock
+import pkg_resources
 import pytest
 
 from google.api_core import exceptions
@@ -401,7 +402,12 @@ def test_create_channel_explicit_scoped(grpc_secure_channel, composite_creds_cal
         target, credentials=credentials, scopes=scopes
     )
 
-    credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
+    # TODO: remove if/else once google-auth >= 1.25.0 is required
+    if pkg_resources.get_distribution("google-auth").version >= "1.25.0":
+        credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
+    else:
+        credentials.with_scopes.assert_called_once_with(scopes)
+
     assert channel is grpc_secure_channel.return_value
     grpc_secure_channel.assert_called_once_with(target, composite_creds)
 
@@ -421,7 +427,12 @@ def test_create_channel_explicit_default_scopes(grpc_secure_channel, composite_c
         target, credentials=credentials, scopes=scopes, default_scopes=default_scopes
     )
 
-    credentials.with_scopes.assert_called_once_with(scopes, default_scopes=default_scopes)
+    # TODO: remove if/else once google-auth >= 1.25.0 is required
+    if pkg_resources.get_distribution("google-auth").version >= "1.25.0":
+        credentials.with_scopes.assert_called_once_with(scopes, default_scopes=default_scopes)
+    else:
+        credentials.with_scopes.assert_called_once_with(scopes)
+
     assert channel is grpc_secure_channel.return_value
     grpc_secure_channel.assert_called_once_with(target, composite_creds)
 
@@ -520,7 +531,12 @@ def test_create_channel_without_grpc_gcp(grpc_secure_channel):
 
     grpc_helpers_async.create_channel(target, credentials=credentials, scopes=scopes)
     grpc_secure_channel.assert_called()
-    credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
+
+    # TODO: remove if/else once google-auth >= 1.25.0 is required
+    if pkg_resources.get_distribution("google-auth").version >= "1.25.0":
+        credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
+    else:
+        credentials.with_scopes.assert_called_once_with(scopes)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_grpc_helpers.py
+++ b/tests/unit/test_grpc_helpers.py
@@ -14,8 +14,6 @@
 
 import grpc
 import mock
-from packaging import version
-import pkg_resources
 import pytest
 
 from google.api_core import exceptions
@@ -236,8 +234,8 @@ def test_create_channel_implicit(grpc_secure_channel, default, composite_creds_c
 
     assert channel is grpc_secure_channel.return_value
 
-    # TODO: remove if/else once google-auth >= 1.25.0 is required
-    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+    # TODO: remove this if/else once google-auth >= 1.25.0 is required
+    if grpc_helpers._GOOGLE_AUTH_HAS_DEFAULT_SCOPES_AND_DEFAULT_HOST:
         default.assert_called_once_with(scopes=None, default_scopes=None)
     else:
         default.assert_called_once_with(scopes=None)
@@ -270,14 +268,16 @@ def test_create_channel_implicit_with_default_host(grpc_secure_channel, default,
 
     assert channel is grpc_secure_channel.return_value
 
-    # TODO: remove if/else once google-auth >= 1.25.0 is required
-    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+    # TODO: remove this if/else once google-auth >= 1.25.0 is required
+    print(grpc_helpers._GOOGLE_AUTH_VERSION)
+    print(grpc_helpers._GOOGLE_AUTH_HAS_DEFAULT_SCOPES_AND_DEFAULT_HOST)
+    if grpc_helpers._GOOGLE_AUTH_HAS_DEFAULT_SCOPES_AND_DEFAULT_HOST:
         default.assert_called_once_with(scopes=None, default_scopes=None)
         auth_metadata_plugin.assert_called_once_with(mock.sentinel.credentials, mock.sentinel.Request, default_host=default_host)
     else:
         default.assert_called_once_with(scopes=None)
         auth_metadata_plugin.assert_called_once_with(mock.sentinel.credentials, mock.sentinel.Request)
-        
+
     if grpc_helpers.HAS_GRPC_GCP:
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
@@ -300,8 +300,8 @@ def test_create_channel_implicit_with_ssl_creds(
 
     grpc_helpers.create_channel(target, ssl_credentials=ssl_creds)
 
-    # TODO: remove if/else once google-auth >= 1.25.0 is required
-    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+    # TODO: remove this if/else once google-auth >= 1.25.0 is required
+    if grpc_helpers._GOOGLE_AUTH_HAS_DEFAULT_SCOPES_AND_DEFAULT_HOST:
         default.assert_called_once_with(scopes=None, default_scopes=None)
     else:
         default.assert_called_once_with(scopes=None)
@@ -331,8 +331,8 @@ def test_create_channel_implicit_with_scopes(
 
     assert channel is grpc_secure_channel.return_value
 
-    # TODO: remove if/else once google-auth >= 1.25.0 is required
-    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+    # TODO: remove this if/else once google-auth >= 1.25.0 is required
+    if grpc_helpers._GOOGLE_AUTH_HAS_DEFAULT_SCOPES_AND_DEFAULT_HOST:
         default.assert_called_once_with(scopes=["one", "two"], default_scopes=None)
     else:
         default.assert_called_once_with(scopes=["one", "two"])
@@ -356,15 +356,15 @@ def test_create_channel_implicit_with_default_scopes(
     target = "example.com:443"
     composite_creds = composite_creds_call.return_value
 
-    channel = grpc_helpers.create_channel(target, scopes=["one", "two"], default_scopes=["three", "four"])
+    channel = grpc_helpers.create_channel(target, default_scopes=["three", "four"])
 
     assert channel is grpc_secure_channel.return_value
 
-    # TODO: remove if/else once google-auth >= 1.25.0 is required
-    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
-        default.assert_called_once_with(scopes=["one", "two"], default_scopes=["three", "four"])
+    # TODO: remove this if/else once google-auth >= 1.25.0 is required
+    if grpc_helpers._GOOGLE_AUTH_HAS_DEFAULT_SCOPES_AND_DEFAULT_HOST:
+        default.assert_called_once_with(scopes=None, default_scopes=["three", "four"])
     else:
-        default.assert_called_once_with(scopes=["one", "two"])
+        default.assert_called_once_with(scopes=["three", "four"])
 
     if grpc_helpers.HAS_GRPC_GCP:
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
@@ -384,7 +384,7 @@ def test_create_channel_explicit_with_duplicate_credentials():
 
 
 @mock.patch("grpc.composite_channel_credentials")
-@mock.patch("google.auth.credentials.with_scopes_if_required")
+@mock.patch("google.auth.credentials.with_scopes_if_required", autospec=True)
 @mock.patch("grpc.secure_channel")
 def test_create_channel_explicit(grpc_secure_channel, auth_creds, composite_creds_call):
     target = "example.com:443"
@@ -392,7 +392,11 @@ def test_create_channel_explicit(grpc_secure_channel, auth_creds, composite_cred
 
     channel = grpc_helpers.create_channel(target, credentials=mock.sentinel.credentials)
 
-    auth_creds.assert_called_once_with(mock.sentinel.credentials, scopes=None, default_scopes=None)
+    # TODO: remove this if/else once google-auth >= 1.25.0 is required
+    if grpc_helpers._GOOGLE_AUTH_HAS_DEFAULT_SCOPES_AND_DEFAULT_HOST:
+        auth_creds.assert_called_once_with(mock.sentinel.credentials, scopes=None, default_scopes=None)
+    else:
+        auth_creds.assert_called_once_with(mock.sentinel.credentials, scopes=None)
     assert channel is grpc_secure_channel.return_value
     if grpc_helpers.HAS_GRPC_GCP:
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
@@ -414,8 +418,8 @@ def test_create_channel_explicit_scoped(grpc_secure_channel, composite_creds_cal
         target, credentials=credentials, scopes=scopes
     )
 
-    # TODO: remove if/else once google-auth >= 1.25.0 is required
-    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+    # TODO: remove this if/else once google-auth >= 1.25.0 is required
+    if grpc_helpers._GOOGLE_AUTH_HAS_DEFAULT_SCOPES_AND_DEFAULT_HOST:
         credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
     else:
         credentials.with_scopes.assert_called_once_with(scopes)
@@ -431,7 +435,6 @@ def test_create_channel_explicit_scoped(grpc_secure_channel, composite_creds_cal
 @mock.patch("grpc.secure_channel")
 def test_create_channel_explicit_default_scopes(grpc_secure_channel, composite_creds_call):
     target = "example.com:443"
-    scopes = ["1", "2"]
     default_scopes = ["3", "4"]
     composite_creds = composite_creds_call.return_value
 
@@ -439,14 +442,14 @@ def test_create_channel_explicit_default_scopes(grpc_secure_channel, composite_c
     credentials.requires_scopes = True
 
     channel = grpc_helpers.create_channel(
-        target, credentials=credentials, scopes=scopes, default_scopes=default_scopes
+        target, credentials=credentials, default_scopes=default_scopes
     )
 
-    # TODO: remove if/else once google-auth >= 1.25.0 is required
-    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
-        credentials.with_scopes.assert_called_once_with(scopes, default_scopes=default_scopes)
+    # TODO: remove this if/else once google-auth >= 1.25.0 is required
+    if grpc_helpers._GOOGLE_AUTH_HAS_DEFAULT_SCOPES_AND_DEFAULT_HOST:
+        credentials.with_scopes.assert_called_once_with(scopes=None, default_scopes=default_scopes)
     else:
-        credentials.with_scopes.assert_called_once_with(scopes)
+        credentials.with_scopes.assert_called_once_with(scopes=default_scopes)
 
     assert channel is grpc_secure_channel.return_value
     if grpc_helpers.HAS_GRPC_GCP:
@@ -495,8 +498,8 @@ def test_create_channel_with_credentials_file(load_credentials_from_file, grpc_s
         target, credentials_file=credentials_file
     )
 
-    # TODO: remove if/else once google-auth >= 1.25.0 is required
-    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+    # TODO: remove this if/else once google-auth >= 1.25.0 is required
+    if grpc_helpers._GOOGLE_AUTH_HAS_DEFAULT_SCOPES_AND_DEFAULT_HOST:
         google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=None, default_scopes=None)
     else:
         google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=None)
@@ -526,8 +529,8 @@ def test_create_channel_with_credentials_file_and_scopes(load_credentials_from_f
         target, credentials_file=credentials_file, scopes=scopes
     )
 
-    # TODO: remove if/else once google-auth >= 1.25.0 is required
-    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+    # TODO: remove this if/else once google-auth >= 1.25.0 is required
+    if grpc_helpers._GOOGLE_AUTH_HAS_DEFAULT_SCOPES_AND_DEFAULT_HOST:
         google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=scopes, default_scopes=None)
     else:
         google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=scopes)
@@ -548,21 +551,20 @@ def test_create_channel_with_credentials_file_and_scopes(load_credentials_from_f
 )
 def test_create_channel_with_credentials_file_and_default_scopes(load_credentials_from_file, grpc_secure_channel, composite_creds_call):
     target = "example.com:443"
-    scopes = ["1", "2"]
     default_scopes = ["3", "4"]
 
     credentials_file = "/path/to/credentials/file.json"
     composite_creds = composite_creds_call.return_value
 
     channel = grpc_helpers.create_channel(
-        target, credentials_file=credentials_file, scopes=scopes, default_scopes=default_scopes
+        target, credentials_file=credentials_file, default_scopes=default_scopes
     )
 
-    # TODO: remove if/else once google-auth >= 1.25.0 is required
-    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
-        load_credentials_from_file.assert_called_once_with(credentials_file, scopes=scopes, default_scopes=default_scopes)
+    # TODO: remove this if/else once google-auth >= 1.25.0 is required
+    if grpc_helpers._GOOGLE_AUTH_HAS_DEFAULT_SCOPES_AND_DEFAULT_HOST:
+        load_credentials_from_file.assert_called_once_with(credentials_file, scopes=None, default_scopes=default_scopes)
     else:
-        load_credentials_from_file.assert_called_once_with(credentials_file, scopes=scopes)
+        load_credentials_from_file.assert_called_once_with(credentials_file, scopes=default_scopes)
 
     assert channel is grpc_secure_channel.return_value
     if grpc_helpers.HAS_GRPC_GCP:
@@ -585,8 +587,8 @@ def test_create_channel_with_grpc_gcp(grpc_gcp_secure_channel):
     grpc_helpers.create_channel(target, credentials=credentials, scopes=scopes)
     grpc_gcp_secure_channel.assert_called()
 
-    # TODO: remove if/else once google-auth >= 1.25.0 is required
-    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+    # TODO: remove this if/else once google-auth >= 1.25.0 is required
+    if grpc_helpers._GOOGLE_AUTH_HAS_DEFAULT_SCOPES_AND_DEFAULT_HOST:
         credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
     else:
         credentials.with_scopes.assert_called_once_with(scopes)
@@ -604,8 +606,8 @@ def test_create_channel_without_grpc_gcp(grpc_secure_channel):
     grpc_helpers.create_channel(target, credentials=credentials, scopes=scopes)
     grpc_secure_channel.assert_called()
 
-    # TODO: remove if/else once google-auth >= 1.25.0 is required
-    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+    # TODO: remove this if/else once google-auth >= 1.25.0 is required
+    if grpc_helpers._GOOGLE_AUTH_HAS_DEFAULT_SCOPES_AND_DEFAULT_HOST:
         credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
     else:
         credentials.with_scopes.assert_called_once_with(scopes)

--- a/tests/unit/test_grpc_helpers.py
+++ b/tests/unit/test_grpc_helpers.py
@@ -232,7 +232,7 @@ def test_create_channel_implicit(grpc_secure_channel, default, composite_creds_c
     channel = grpc_helpers.create_channel(target)
 
     assert channel is grpc_secure_channel.return_value
-    default.assert_called_once_with(scopes=None)
+    default.assert_called_once_with(scopes=None, default_scopes=None)
     if grpc_helpers.HAS_GRPC_GCP:
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
@@ -254,7 +254,7 @@ def test_create_channel_implicit_with_ssl_creds(
 
     grpc_helpers.create_channel(target, ssl_credentials=ssl_creds)
 
-    default.assert_called_once_with(scopes=None)
+    default.assert_called_once_with(scopes=None, default_scopes=None)
     composite_creds_call.assert_called_once_with(ssl_creds, mock.ANY)
     composite_creds = composite_creds_call.return_value
     if grpc_helpers.HAS_GRPC_GCP:
@@ -278,7 +278,7 @@ def test_create_channel_implicit_with_scopes(
     channel = grpc_helpers.create_channel(target, scopes=["one", "two"])
 
     assert channel is grpc_secure_channel.return_value
-    default.assert_called_once_with(scopes=["one", "two"])
+    default.assert_called_once_with(scopes=["one", "two"], default_scopes=None)
     if grpc_helpers.HAS_GRPC_GCP:
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
@@ -305,7 +305,7 @@ def test_create_channel_explicit(grpc_secure_channel, auth_creds, composite_cred
 
     channel = grpc_helpers.create_channel(target, credentials=mock.sentinel.credentials)
 
-    auth_creds.assert_called_once_with(mock.sentinel.credentials, None)
+    auth_creds.assert_called_once_with(mock.sentinel.credentials, scopes=None, default_scopes=None)
     assert channel is grpc_secure_channel.return_value
     if grpc_helpers.HAS_GRPC_GCP:
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
@@ -327,7 +327,7 @@ def test_create_channel_explicit_scoped(grpc_secure_channel, composite_creds_cal
         target, credentials=credentials, scopes=scopes
     )
 
-    credentials.with_scopes.assert_called_once_with(scopes)
+    credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
     assert channel is grpc_secure_channel.return_value
     if grpc_helpers.HAS_GRPC_GCP:
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
@@ -374,7 +374,7 @@ def test_create_channel_with_credentials_file(load_credentials_from_file, grpc_s
         target, credentials_file=credentials_file
     )
 
-    google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=None)
+    google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=None, default_scopes=None)
 
     assert channel is grpc_secure_channel.return_value
     if grpc_helpers.HAS_GRPC_GCP:
@@ -400,7 +400,7 @@ def test_create_channel_with_credentials_file_and_scopes(load_credentials_from_f
         target, credentials_file=credentials_file, scopes=scopes
     )
 
-    google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=scopes)
+    google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=scopes, default_scopes=None)
     assert channel is grpc_secure_channel.return_value
     if grpc_helpers.HAS_GRPC_GCP:
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
@@ -421,7 +421,7 @@ def test_create_channel_with_grpc_gcp(grpc_gcp_secure_channel):
 
     grpc_helpers.create_channel(target, credentials=credentials, scopes=scopes)
     grpc_gcp_secure_channel.assert_called()
-    credentials.with_scopes.assert_called_once_with(scopes)
+    credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
 
 
 @pytest.mark.skipif(grpc_helpers.HAS_GRPC_GCP, reason="grpc_gcp module not available")
@@ -435,7 +435,7 @@ def test_create_channel_without_grpc_gcp(grpc_secure_channel):
 
     grpc_helpers.create_channel(target, credentials=credentials, scopes=scopes)
     grpc_secure_channel.assert_called()
-    credentials.with_scopes.assert_called_once_with(scopes)
+    credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
 
 
 class TestChannelStub(object):

--- a/tests/unit/test_grpc_helpers.py
+++ b/tests/unit/test_grpc_helpers.py
@@ -14,6 +14,7 @@
 
 import grpc
 import mock
+from packaging import version
 import pkg_resources
 import pytest
 
@@ -223,6 +224,7 @@ def test_wrap_errors_streaming(wrap_stream_errors):
 @mock.patch("grpc.composite_channel_credentials")
 @mock.patch(
     "google.auth.default",
+    autospec=True,
     return_value=(mock.sentinel.credentials, mock.sentinel.projet),
 )
 @mock.patch("grpc.secure_channel")
@@ -233,21 +235,29 @@ def test_create_channel_implicit(grpc_secure_channel, default, composite_creds_c
     channel = grpc_helpers.create_channel(target)
 
     assert channel is grpc_secure_channel.return_value
-    default.assert_called_once_with(scopes=None, default_scopes=None)
+
+    # TODO: remove if/else once google-auth >= 1.25.0 is required
+    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+        default.assert_called_once_with(scopes=None, default_scopes=None)
+    else:
+        default.assert_called_once_with(scopes=None)
+
     if grpc_helpers.HAS_GRPC_GCP:
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
 
 
-@mock.patch("google.auth.transport.grpc.AuthMetadataPlugin")
+@mock.patch("google.auth.transport.grpc.AuthMetadataPlugin", autospec=True)
 @mock.patch(
     "google.auth.transport.requests.Request",
+    autospec=True,
     return_value=mock.sentinel.Request
 )
 @mock.patch("grpc.composite_channel_credentials")
 @mock.patch(
     "google.auth.default",
+    autospec=True,
     return_value=(mock.sentinel.credentials, mock.sentinel.project),
 )
 @mock.patch("grpc.secure_channel")
@@ -259,9 +269,15 @@ def test_create_channel_implicit_with_default_host(grpc_secure_channel, default,
     channel = grpc_helpers.create_channel(target, default_host=default_host)
 
     assert channel is grpc_secure_channel.return_value
-    default.assert_called_once_with(scopes=None, default_scopes=None)
-    auth_metadata_plugin.assert_called_once_with(mock.sentinel.credentials, mock.sentinel.Request, default_host=default_host)
 
+    # TODO: remove if/else once google-auth >= 1.25.0 is required
+    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+        default.assert_called_once_with(scopes=None, default_scopes=None)
+        auth_metadata_plugin.assert_called_once_with(mock.sentinel.credentials, mock.sentinel.Request, default_host=default_host)
+    else:
+        default.assert_called_once_with(scopes=None)
+        auth_metadata_plugin.assert_called_once_with(mock.sentinel.credentials, mock.sentinel.Request)
+        
     if grpc_helpers.HAS_GRPC_GCP:
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
@@ -271,6 +287,7 @@ def test_create_channel_implicit_with_default_host(grpc_secure_channel, default,
 @mock.patch("grpc.composite_channel_credentials")
 @mock.patch(
     "google.auth.default",
+    autospec=True,
     return_value=(mock.sentinel.credentials, mock.sentinel.projet),
 )
 @mock.patch("grpc.secure_channel")
@@ -283,7 +300,12 @@ def test_create_channel_implicit_with_ssl_creds(
 
     grpc_helpers.create_channel(target, ssl_credentials=ssl_creds)
 
-    default.assert_called_once_with(scopes=None, default_scopes=None)
+    # TODO: remove if/else once google-auth >= 1.25.0 is required
+    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+        default.assert_called_once_with(scopes=None, default_scopes=None)
+    else:
+        default.assert_called_once_with(scopes=None)
+
     composite_creds_call.assert_called_once_with(ssl_creds, mock.ANY)
     composite_creds = composite_creds_call.return_value
     if grpc_helpers.HAS_GRPC_GCP:
@@ -295,6 +317,7 @@ def test_create_channel_implicit_with_ssl_creds(
 @mock.patch("grpc.composite_channel_credentials")
 @mock.patch(
     "google.auth.default",
+    autospec=True,
     return_value=(mock.sentinel.credentials, mock.sentinel.projet),
 )
 @mock.patch("grpc.secure_channel")
@@ -307,7 +330,13 @@ def test_create_channel_implicit_with_scopes(
     channel = grpc_helpers.create_channel(target, scopes=["one", "two"])
 
     assert channel is grpc_secure_channel.return_value
-    default.assert_called_once_with(scopes=["one", "two"], default_scopes=None)
+
+    # TODO: remove if/else once google-auth >= 1.25.0 is required
+    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+        default.assert_called_once_with(scopes=["one", "two"], default_scopes=None)
+    else:
+        default.assert_called_once_with(scopes=["one", "two"])
+
     if grpc_helpers.HAS_GRPC_GCP:
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
@@ -317,6 +346,7 @@ def test_create_channel_implicit_with_scopes(
 @mock.patch("grpc.composite_channel_credentials")
 @mock.patch(
     "google.auth.default",
+    autospec=True,
     return_value=(mock.sentinel.credentials, mock.sentinel.projet),
 )
 @mock.patch("grpc.secure_channel")
@@ -329,7 +359,13 @@ def test_create_channel_implicit_with_default_scopes(
     channel = grpc_helpers.create_channel(target, scopes=["one", "two"], default_scopes=["three", "four"])
 
     assert channel is grpc_secure_channel.return_value
-    default.assert_called_once_with(scopes=["one", "two"], default_scopes=["three", "four"])
+
+    # TODO: remove if/else once google-auth >= 1.25.0 is required
+    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+        default.assert_called_once_with(scopes=["one", "two"], default_scopes=["three", "four"])
+    else:
+        default.assert_called_once_with(scopes=["one", "two"])
+
     if grpc_helpers.HAS_GRPC_GCP:
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
@@ -379,7 +415,7 @@ def test_create_channel_explicit_scoped(grpc_secure_channel, composite_creds_cal
     )
 
     # TODO: remove if/else once google-auth >= 1.25.0 is required
-    if pkg_resources.get_distribution("google-auth").version >= "1.25.0":
+    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
         credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
     else:
         credentials.with_scopes.assert_called_once_with(scopes)
@@ -407,7 +443,7 @@ def test_create_channel_explicit_default_scopes(grpc_secure_channel, composite_c
     )
 
     # TODO: remove if/else once google-auth >= 1.25.0 is required
-    if pkg_resources.get_distribution("google-auth").version >= "1.25.0":
+    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
         credentials.with_scopes.assert_called_once_with(scopes, default_scopes=default_scopes)
     else:
         credentials.with_scopes.assert_called_once_with(scopes)
@@ -446,6 +482,7 @@ def test_create_channel_explicit_with_quota_project(grpc_secure_channel, composi
 @mock.patch("grpc.secure_channel")
 @mock.patch(
     "google.auth.load_credentials_from_file",
+    autospec=True,
     return_value=(mock.sentinel.credentials, mock.sentinel.project)
 )
 def test_create_channel_with_credentials_file(load_credentials_from_file, grpc_secure_channel, composite_creds_call):
@@ -458,7 +495,11 @@ def test_create_channel_with_credentials_file(load_credentials_from_file, grpc_s
         target, credentials_file=credentials_file
     )
 
-    google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=None, default_scopes=None)
+    # TODO: remove if/else once google-auth >= 1.25.0 is required
+    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+        google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=None, default_scopes=None)
+    else:
+        google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=None)
 
     assert channel is grpc_secure_channel.return_value
     if grpc_helpers.HAS_GRPC_GCP:
@@ -471,6 +512,7 @@ def test_create_channel_with_credentials_file(load_credentials_from_file, grpc_s
 @mock.patch("grpc.secure_channel")
 @mock.patch(
     "google.auth.load_credentials_from_file",
+    autospec=True,
     return_value=(mock.sentinel.credentials, mock.sentinel.project)
 )
 def test_create_channel_with_credentials_file_and_scopes(load_credentials_from_file, grpc_secure_channel, composite_creds_call):
@@ -484,7 +526,12 @@ def test_create_channel_with_credentials_file_and_scopes(load_credentials_from_f
         target, credentials_file=credentials_file, scopes=scopes
     )
 
-    google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=scopes, default_scopes=None)
+    # TODO: remove if/else once google-auth >= 1.25.0 is required
+    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+        google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=scopes, default_scopes=None)
+    else:
+        google.auth.load_credentials_from_file.assert_called_once_with(credentials_file, scopes=scopes)
+
     assert channel is grpc_secure_channel.return_value
     if grpc_helpers.HAS_GRPC_GCP:
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
@@ -496,6 +543,7 @@ def test_create_channel_with_credentials_file_and_scopes(load_credentials_from_f
 @mock.patch("grpc.secure_channel")
 @mock.patch(
     "google.auth.load_credentials_from_file",
+    autospec=True,
     return_value=(mock.sentinel.credentials, mock.sentinel.project)
 )
 def test_create_channel_with_credentials_file_and_default_scopes(load_credentials_from_file, grpc_secure_channel, composite_creds_call):
@@ -510,7 +558,12 @@ def test_create_channel_with_credentials_file_and_default_scopes(load_credential
         target, credentials_file=credentials_file, scopes=scopes, default_scopes=default_scopes
     )
 
-    load_credentials_from_file.assert_called_once_with(credentials_file, scopes=scopes, default_scopes=default_scopes)
+    # TODO: remove if/else once google-auth >= 1.25.0 is required
+    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+        load_credentials_from_file.assert_called_once_with(credentials_file, scopes=scopes, default_scopes=default_scopes)
+    else:
+        load_credentials_from_file.assert_called_once_with(credentials_file, scopes=scopes)
+
     assert channel is grpc_secure_channel.return_value
     if grpc_helpers.HAS_GRPC_GCP:
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
@@ -531,7 +584,12 @@ def test_create_channel_with_grpc_gcp(grpc_gcp_secure_channel):
 
     grpc_helpers.create_channel(target, credentials=credentials, scopes=scopes)
     grpc_gcp_secure_channel.assert_called()
-    credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
+
+    # TODO: remove if/else once google-auth >= 1.25.0 is required
+    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
+        credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
+    else:
+        credentials.with_scopes.assert_called_once_with(scopes)
 
 
 @pytest.mark.skipif(grpc_helpers.HAS_GRPC_GCP, reason="grpc_gcp module not available")
@@ -547,7 +605,7 @@ def test_create_channel_without_grpc_gcp(grpc_secure_channel):
     grpc_secure_channel.assert_called()
 
     # TODO: remove if/else once google-auth >= 1.25.0 is required
-    if pkg_resources.get_distribution("google-auth").version >= "1.25.0":
+    if version.Version(pkg_resources.get_distribution("google-auth").version) >= version.Version("1.25.0"):
         credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
     else:
         credentials.with_scopes.assert_called_once_with(scopes)

--- a/tests/unit/test_grpc_helpers.py
+++ b/tests/unit/test_grpc_helpers.py
@@ -285,6 +285,28 @@ def test_create_channel_implicit_with_scopes(
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
 
 
+@mock.patch("grpc.composite_channel_credentials")
+@mock.patch(
+    "google.auth.default",
+    return_value=(mock.sentinel.credentials, mock.sentinel.projet),
+)
+@mock.patch("grpc.secure_channel")
+def test_create_channel_implicit_with_default_scopes(
+    grpc_secure_channel, default, composite_creds_call
+):
+    target = "example.com:443"
+    composite_creds = composite_creds_call.return_value
+
+    channel = grpc_helpers.create_channel(target, scopes=["one", "two"], default_scopes=["three", "four"])
+
+    assert channel is grpc_secure_channel.return_value
+    default.assert_called_once_with(scopes=["one", "two"], default_scopes=["three", "four"])
+    if grpc_helpers.HAS_GRPC_GCP:
+        grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
+    else:
+        grpc_secure_channel.assert_called_once_with(target, composite_creds)
+
+
 def test_create_channel_explicit_with_duplicate_credentials():
     target = "example.com:443"
 
@@ -328,6 +350,29 @@ def test_create_channel_explicit_scoped(grpc_secure_channel, composite_creds_cal
     )
 
     credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
+    assert channel is grpc_secure_channel.return_value
+    if grpc_helpers.HAS_GRPC_GCP:
+        grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
+    else:
+        grpc_secure_channel.assert_called_once_with(target, composite_creds)
+   
+
+@mock.patch("grpc.composite_channel_credentials")
+@mock.patch("grpc.secure_channel")
+def test_create_channel_explicit_default_scopes(grpc_secure_channel, composite_creds_call):
+    target = "example.com:443"
+    scopes = ["1", "2"]
+    default_scopes = ["3", "4"]
+    composite_creds = composite_creds_call.return_value
+
+    credentials = mock.create_autospec(google.auth.credentials.Scoped, instance=True)
+    credentials.requires_scopes = True
+
+    channel = grpc_helpers.create_channel(
+        target, credentials=credentials, scopes=scopes, default_scopes=default_scopes
+    )
+
+    credentials.with_scopes.assert_called_once_with(scopes, default_scopes=default_scopes)
     assert channel is grpc_secure_channel.return_value
     if grpc_helpers.HAS_GRPC_GCP:
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
@@ -406,6 +451,33 @@ def test_create_channel_with_credentials_file_and_scopes(load_credentials_from_f
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
+
+
+@mock.patch("grpc.composite_channel_credentials")
+@mock.patch("grpc.secure_channel")
+@mock.patch(
+    "google.auth.load_credentials_from_file",
+    return_value=(mock.sentinel.credentials, mock.sentinel.project)
+)
+def test_create_channel_with_credentials_file_and_default_scopes(load_credentials_from_file, grpc_secure_channel, composite_creds_call):
+    target = "example.com:443"
+    scopes = ["1", "2"]
+    default_scopes = ["3", "4"]
+
+    credentials_file = "/path/to/credentials/file.json"
+    composite_creds = composite_creds_call.return_value
+
+    channel = grpc_helpers.create_channel(
+        target, credentials_file=credentials_file, scopes=scopes, default_scopes=default_scopes
+    )
+
+    load_credentials_from_file.assert_called_once_with(credentials_file, scopes=scopes, default_scopes=default_scopes)
+    assert channel is grpc_secure_channel.return_value
+    if grpc_helpers.HAS_GRPC_GCP:
+        grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
+    else:
+        grpc_secure_channel.assert_called_once_with(target, composite_creds)
+
 
 
 @pytest.mark.skipif(

--- a/tests/unit/test_grpc_helpers.py
+++ b/tests/unit/test_grpc_helpers.py
@@ -14,6 +14,7 @@
 
 import grpc
 import mock
+import pkg_resources
 import pytest
 
 from google.api_core import exceptions
@@ -377,7 +378,12 @@ def test_create_channel_explicit_scoped(grpc_secure_channel, composite_creds_cal
         target, credentials=credentials, scopes=scopes
     )
 
-    credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
+    # TODO: remove if/else once google-auth >= 1.25.0 is required
+    if pkg_resources.get_distribution("google-auth").version >= "1.25.0":
+        credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
+    else:
+        credentials.with_scopes.assert_called_once_with(scopes)
+
     assert channel is grpc_secure_channel.return_value
     if grpc_helpers.HAS_GRPC_GCP:
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
@@ -400,7 +406,12 @@ def test_create_channel_explicit_default_scopes(grpc_secure_channel, composite_c
         target, credentials=credentials, scopes=scopes, default_scopes=default_scopes
     )
 
-    credentials.with_scopes.assert_called_once_with(scopes, default_scopes=default_scopes)
+    # TODO: remove if/else once google-auth >= 1.25.0 is required
+    if pkg_resources.get_distribution("google-auth").version >= "1.25.0":
+        credentials.with_scopes.assert_called_once_with(scopes, default_scopes=default_scopes)
+    else:
+        credentials.with_scopes.assert_called_once_with(scopes)
+
     assert channel is grpc_secure_channel.return_value
     if grpc_helpers.HAS_GRPC_GCP:
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
@@ -534,7 +545,12 @@ def test_create_channel_without_grpc_gcp(grpc_secure_channel):
 
     grpc_helpers.create_channel(target, credentials=credentials, scopes=scopes)
     grpc_secure_channel.assert_called()
-    credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
+
+    # TODO: remove if/else once google-auth >= 1.25.0 is required
+    if pkg_resources.get_distribution("google-auth").version >= "1.25.0":
+        credentials.with_scopes.assert_called_once_with(scopes, default_scopes=None)
+    else:
+        credentials.with_scopes.assert_called_once_with(scopes)
 
 
 class TestChannelStub(object):


### PR DESCRIPTION
Add `default_host` and `default_scopes` parameters to `create_channel` so self-signed JWTs can be used. See https://github.com/googleapis/google-auth-library-python/pull/665 for the change in the auth library and https://github.com/googleapis/python-translate/pull/107 for the changes in the GAPIC library.
