### PR TITLE
fix: add operation name to x-goog-request-params in async client

### DIFF
--- a/google/api_core/operations_v1/operations_async_client.py
+++ b/google/api_core/operations_v1/operations_async_client.py
@@ -120,6 +120,11 @@ class OperationsAsyncClient:
                 subclass will be raised.
         """
         request = operations_pb2.GetOperationRequest(name=name)
+
+        # Add routing header
+        metadata = metadata or []
+        metadata.append(gapic_v1.routing_header.to_grpc_metadata({"name": name}))
+
         return await self._get_operation(request, retry=retry, timeout=timeout, metadata=metadata)
 
     async def list_operations(
@@ -181,6 +186,10 @@ class OperationsAsyncClient:
         """
         # Create the request object.
         request = operations_pb2.ListOperationsRequest(name=name, filter=filter_)
+
+        # Add routing header
+        metadata = metadata or []
+        metadata.append(gapic_v1.routing_header.to_grpc_metadata({"name": name}))
 
         # Create the method used to fetch pages
         method = functools.partial(self._list_operations, retry=retry, timeout=timeout, metadata=metadata)
@@ -246,6 +255,11 @@ class OperationsAsyncClient:
         """
         # Create the request object.
         request = operations_pb2.CancelOperationRequest(name=name)
+
+        # Add routing header
+        metadata = metadata or []
+        metadata.append(gapic_v1.routing_header.to_grpc_metadata({"name": name}))
+
         await self._cancel_operation(request, retry=retry, timeout=timeout, metadata=metadata)
 
     async def delete_operation(
@@ -292,4 +306,9 @@ class OperationsAsyncClient:
         """
         # Create the request object.
         request = operations_pb2.DeleteOperationRequest(name=name)
+
+        # Add routing header
+        metadata = metadata or []
+        metadata.append(gapic_v1.routing_header.to_grpc_metadata({"name": name}))
+
         await self._delete_operation(request, retry=retry, timeout=timeout, metadata=metadata)

--- a/google/api_core/operations_v1/operations_client.py
+++ b/google/api_core/operations_v1/operations_client.py
@@ -137,7 +137,7 @@ class OperationsClient(object):
 
         # Add routing header
         metadata = metadata or []
-        metadata = metadata + [gapic_v1.routing_header.to_grpc_metadata({"name": name})]
+        metadata.append(gapic_v1.routing_header.to_grpc_metadata({"name": name}))
 
         return self._get_operation(request, retry=retry, timeout=timeout, metadata=metadata)
 
@@ -203,7 +203,7 @@ class OperationsClient(object):
 
         # Add routing header
         metadata = metadata or []
-        metadata = metadata + [gapic_v1.routing_header.to_grpc_metadata({"name": name})]
+        metadata.append(gapic_v1.routing_header.to_grpc_metadata({"name": name}))
 
         # Create the method used to fetch pages
         method = functools.partial(self._list_operations, retry=retry, timeout=timeout, metadata=metadata)
@@ -272,7 +272,7 @@ class OperationsClient(object):
 
         # Add routing header
         metadata = metadata or []
-        metadata = metadata + [gapic_v1.routing_header.to_grpc_metadata({"name": name})]
+        metadata.append(gapic_v1.routing_header.to_grpc_metadata({"name": name}))
 
         self._cancel_operation(request, retry=retry, timeout=timeout, metadata=metadata)
 
@@ -323,6 +323,6 @@ class OperationsClient(object):
 
         # Add routing header
         metadata = metadata or []
-        metadata = metadata + [gapic_v1.routing_header.to_grpc_metadata({"name": name})]
+        metadata.append(gapic_v1.routing_header.to_grpc_metadata({"name": name}))
 
         self._delete_operation(request, retry=retry, timeout=timeout, metadata=metadata)

--- a/google/api_core/operations_v1/operations_client.py
+++ b/google/api_core/operations_v1/operations_client.py
@@ -134,6 +134,11 @@ class OperationsClient(object):
                 subclass will be raised.
         """
         request = operations_pb2.GetOperationRequest(name=name)
+
+        # Add routing header
+        metadata = metadata or []
+        metadata = metadata + [gapic_v1.routing_header.to_grpc_metadata({"name": name})]
+
         return self._get_operation(request, retry=retry, timeout=timeout, metadata=metadata)
 
     def list_operations(
@@ -195,6 +200,10 @@ class OperationsClient(object):
         """
         # Create the request object.
         request = operations_pb2.ListOperationsRequest(name=name, filter=filter_)
+
+        # Add routing header
+        metadata = metadata or []
+        metadata = metadata + [gapic_v1.routing_header.to_grpc_metadata({"name": name})]
 
         # Create the method used to fetch pages
         method = functools.partial(self._list_operations, retry=retry, timeout=timeout, metadata=metadata)
@@ -260,6 +269,11 @@ class OperationsClient(object):
         """
         # Create the request object.
         request = operations_pb2.CancelOperationRequest(name=name)
+
+        # Add routing header
+        metadata = metadata or []
+        metadata = metadata + [gapic_v1.routing_header.to_grpc_metadata({"name": name})]
+
         self._cancel_operation(request, retry=retry, timeout=timeout, metadata=metadata)
 
     def delete_operation(
@@ -306,4 +320,9 @@ class OperationsClient(object):
         """
         # Create the request object.
         request = operations_pb2.DeleteOperationRequest(name=name)
+
+        # Add routing header
+        metadata = metadata or []
+        metadata = metadata + [gapic_v1.routing_header.to_grpc_metadata({"name": name})]
+
         self._delete_operation(request, retry=retry, timeout=timeout, metadata=metadata)

--- a/tests/asyncio/operations_v1/test_operations_async_client.py
+++ b/tests/asyncio/operations_v1/test_operations_async_client.py
@@ -36,10 +36,11 @@ async def test_get_operation():
         operations_pb2.Operation(name="meep"))
     client = operations_v1.OperationsAsyncClient(mocked_channel)
 
-    response = await client.get_operation("name", metadata=[("x-goog-request-params", "foo")])
+    response = await client.get_operation("name", metadata=[("header", "foo")])
     assert method.call_count == 1
     assert tuple(method.call_args_list[0])[0][0].name == "name"
-    assert ("x-goog-request-params", "foo") in tuple(method.call_args_list[0])[1]["metadata"]
+    assert ("header", "foo") in tuple(method.call_args_list[0])[1]["metadata"]
+    assert ("x-goog-request-params", "name=name") in tuple(method.call_args_list[0])[1]["metadata"]
     assert response == fake_call.response
 
 
@@ -54,7 +55,7 @@ async def test_list_operations():
     mocked_channel, method, fake_call = _mock_grpc_objects(list_response)
     client = operations_v1.OperationsAsyncClient(mocked_channel)
 
-    pager = await client.list_operations("name", "filter", metadata=[("x-goog-request-params", "foo")])
+    pager = await client.list_operations("name", "filter", metadata=[("header", "foo")])
 
     assert isinstance(pager, page_iterator_async.AsyncIterator)
     responses = []
@@ -64,7 +65,8 @@ async def test_list_operations():
     assert responses == operations
 
     assert method.call_count == 1
-    assert ("x-goog-request-params", "foo") in tuple(method.call_args_list[0])[1]["metadata"]
+    assert ("header", "foo") in tuple(method.call_args_list[0])[1]["metadata"]
+    assert ("x-goog-request-params", "name=name") in tuple(method.call_args_list[0])[1]["metadata"]
     request = tuple(method.call_args_list[0])[0][0]
     assert isinstance(request, operations_pb2.ListOperationsRequest)
     assert request.name == "name"
@@ -77,11 +79,12 @@ async def test_delete_operation():
         empty_pb2.Empty())
     client = operations_v1.OperationsAsyncClient(mocked_channel)
 
-    await client.delete_operation("name", metadata=[("x-goog-request-params", "foo")])
+    await client.delete_operation("name", metadata=[("header", "foo")])
 
     assert method.call_count == 1
     assert tuple(method.call_args_list[0])[0][0].name == "name"
-    assert ("x-goog-request-params", "foo") in tuple(method.call_args_list[0])[1]["metadata"]
+    assert ("header", "foo") in tuple(method.call_args_list[0])[1]["metadata"]
+    assert ("x-goog-request-params", "name=name") in tuple(method.call_args_list[0])[1]["metadata"]
 
 
 @pytest.mark.asyncio
@@ -90,8 +93,9 @@ async def test_cancel_operation():
         empty_pb2.Empty())
     client = operations_v1.OperationsAsyncClient(mocked_channel)
 
-    await client.cancel_operation("name", metadata=[("x-goog-request-params", "foo")])
+    await client.cancel_operation("name", metadata=[("header", "foo")])
 
     assert method.call_count == 1
     assert tuple(method.call_args_list[0])[0][0].name == "name"
-    assert ("x-goog-request-params", "foo") in tuple(method.call_args_list[0])[1]["metadata"]
+    assert ("header", "foo") in tuple(method.call_args_list[0])[1]["metadata"]
+    assert ("x-goog-request-params", "name=name") in tuple(method.call_args_list[0])[1]["metadata"]

--- a/tests/unit/operations_v1/test_operations_client.py
+++ b/tests/unit/operations_v1/test_operations_client.py
@@ -24,9 +24,10 @@ def test_get_operation():
     client = operations_v1.OperationsClient(channel)
     channel.GetOperation.response = operations_pb2.Operation(name="meep")
 
-    response = client.get_operation("name", metadata=[("x-goog-request-params", "foo")])
+    response = client.get_operation("name", metadata=[("header", "foo")])
 
-    assert ("x-goog-request-params", "foo") in channel.GetOperation.calls[0].metadata
+    assert ("header", "foo") in channel.GetOperation.calls[0].metadata
+    assert ("x-goog-request-params", "name=name") in channel.GetOperation.calls[0].metadata
     assert len(channel.GetOperation.requests) == 1
     assert channel.GetOperation.requests[0].name == "name"
     assert response == channel.GetOperation.response
@@ -42,12 +43,13 @@ def test_list_operations():
     list_response = operations_pb2.ListOperationsResponse(operations=operations)
     channel.ListOperations.response = list_response
 
-    response = client.list_operations("name", "filter", metadata=[("x-goog-request-params", "foo")])
+    response = client.list_operations("name", "filter", metadata=[("header", "foo")])
 
     assert isinstance(response, page_iterator.Iterator)
     assert list(response) == operations
 
-    assert ("x-goog-request-params", "foo") in channel.ListOperations.calls[0].metadata
+    assert ("header", "foo") in channel.ListOperations.calls[0].metadata
+    assert ("x-goog-request-params", "name=name") in channel.ListOperations.calls[0].metadata
     assert len(channel.ListOperations.requests) == 1
     request = channel.ListOperations.requests[0]
     assert isinstance(request, operations_pb2.ListOperationsRequest)
@@ -60,9 +62,10 @@ def test_delete_operation():
     client = operations_v1.OperationsClient(channel)
     channel.DeleteOperation.response = empty_pb2.Empty()
 
-    client.delete_operation("name", metadata=[("x-goog-request-params", "foo")])
+    client.delete_operation("name", metadata=[("header", "foo")])
 
-    assert ("x-goog-request-params", "foo") in channel.DeleteOperation.calls[0].metadata
+    assert ("header", "foo") in channel.DeleteOperation.calls[0].metadata
+    assert ("x-goog-request-params", "name=name") in channel.DeleteOperation.calls[0].metadata
     assert len(channel.DeleteOperation.requests) == 1
     assert channel.DeleteOperation.requests[0].name == "name"
 
@@ -72,8 +75,9 @@ def test_cancel_operation():
     client = operations_v1.OperationsClient(channel)
     channel.CancelOperation.response = empty_pb2.Empty()
 
-    client.cancel_operation("name", metadata=[("x-goog-request-params", "foo")])
+    client.cancel_operation("name", metadata=[("header", "foo")])
 
-    assert ("x-goog-request-params", "foo") in channel.CancelOperation.calls[0].metadata
+    assert ("header", "foo") in channel.CancelOperation.calls[0].metadata
+    assert ("x-goog-request-params", "name=name") in channel.CancelOperation.calls[0].metadata
     assert len(channel.CancelOperation.requests) == 1
     assert channel.CancelOperation.requests[0].name == "name"


### PR DESCRIPTION
Pass the operation name in the `x-goog-request-params`header.
 
Same as #133 for the async operations client.

