### PR TITLE
commented out removed retry decorator from arguments.  No longer used…

### DIFF
--- a/google/api_core/gapic_v1/method.py
+++ b/google/api_core/gapic_v1/method.py
@@ -129,7 +129,9 @@ class _GapicCallable(object):
             retry = self._retry
 
         # Apply all applicable decorators.
-        wrapped_func = _apply_decorators(self._target, [retry, timeout_])
+        #retry decorator no longer in use 
+        # wrapped_func = _apply_decorators(self._target, [retry, timeout_])
+        wrapped_func = _apply_decorators(self._target, [timeout_])
 
         # Add the user agent metadata to the call.
         if self._metadata is not None:


### PR DESCRIPTION
… or imported.  Retry value was being passed instead and then called causing an 'int not callable' exception

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-api-core/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #143 🦕
