### PR TITLE
chore: remove reference to blacken in contrib

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -98,11 +98,6 @@ On Debian/Ubuntu::
 ************
 Coding Style
 ************
-- We use the automatic code formatter ``black``. You can run it using
-  the nox session ``blacken``. This will eliminate many lint errors. Run via::
-
-   $ nox -s blacken
-
 - PEP8 compliance is required, with exceptions defined in the linter configuration.
   If you have ``nox`` installed, you can test that you have not introduced
   any non-compliant code via::


### PR DESCRIPTION
Removes reference to the `blacken` `nox` session as it doesn't exist in the `noxfile.py`. 