### PR TITLE
feat: Add support for `rest/` token in `x-goog-api-client` header

### DIFF
--- a/google/api_core/client_info.py
+++ b/google/api_core/client_info.py
@@ -54,6 +54,7 @@ class ClientInfo(object):
         user_agent (Optional[str]): Prefix to the user agent header. This is
             used to supply information such as application name or partner tool.
             Recommended format: ``application-or-tool-ID/major.minor.version``.
+        rest_version (Optional[str]): The requests library version.
     """
 
     def __init__(
@@ -64,6 +65,7 @@ class ClientInfo(object):
         gapic_version=None,
         client_library_version=None,
         user_agent=None,
+        rest_version=None,
     ):
         self.python_version = python_version
         self.grpc_version = grpc_version
@@ -71,6 +73,7 @@ class ClientInfo(object):
         self.gapic_version = gapic_version
         self.client_library_version = client_library_version
         self.user_agent = user_agent
+        self.rest_version = rest_version
 
     def to_user_agent(self):
         """Returns the user-agent string for this client info."""
@@ -86,6 +89,9 @@ class ClientInfo(object):
 
         if self.grpc_version is not None:
             ua += "grpc/{grpc_version} "
+
+        if self.rest_version is not None:
+            ua += "rest/{rest_version} "
 
         ua += "gax/{api_core_version} "
 

--- a/tests/unit/test_client_info.py
+++ b/tests/unit/test_client_info.py
@@ -24,6 +24,7 @@ def test_constructor_defaults():
     assert info.api_core_version is not None
     assert info.gapic_version is None
     assert info.client_library_version is None
+    assert info.rest_version is None
 
 
 def test_constructor_options():
@@ -33,7 +34,8 @@ def test_constructor_options():
         api_core_version="3",
         gapic_version="4",
         client_library_version="5",
-        user_agent="6"
+        user_agent="6",
+        rest_version="7",
     )
 
     assert info.python_version == "1"
@@ -42,6 +44,7 @@ def test_constructor_options():
     assert info.gapic_version == "4"
     assert info.client_library_version == "5"
     assert info.user_agent == "6"
+    assert info.rest_version == "7"
 
 
 def test_to_user_agent_minimal():
@@ -67,3 +70,18 @@ def test_to_user_agent_full():
     user_agent = info.to_user_agent()
 
     assert user_agent == "app-name/1.0 gl-python/1 grpc/2 gax/3 gapic/4 gccl/5"
+
+def test_to_user_agent_rest():
+    info = client_info.ClientInfo(
+        python_version="1",
+        grpc_version=None,
+        rest_version="2",
+        api_core_version="3",
+        gapic_version="4",
+        client_library_version="5",
+        user_agent="app-name/1.0",
+    )
+
+    user_agent = info.to_user_agent()
+
+    assert user_agent == "app-name/1.0 gl-python/1 rest/2 gax/3 gapic/4 gccl/5"

--- a/tests/unit/test_client_info.py
+++ b/tests/unit/test_client_info.py
@@ -71,6 +71,7 @@ def test_to_user_agent_full():
 
     assert user_agent == "app-name/1.0 gl-python/1 grpc/2 gax/3 gapic/4 gccl/5"
 
+
 def test_to_user_agent_rest():
     info = client_info.ClientInfo(
         python_version="1",


### PR DESCRIPTION
This is required for (DI)REGAPIC clients, like GCE client.

