### PR TITLE
feat: Bidi uses metadata from start_rpc

### DIFF
--- a/google/api_core/bidi.py
+++ b/google/api_core/bidi.py
@@ -240,7 +240,8 @@ class BidiRpc(object):
             yield. This is useful if an initial request is needed to start the
             stream.
         metadata (Sequence[Tuple(str, str)]): RPC metadata to include in
-            the request.
+            the request. If no metadata is provided, metadata from
+            start_rpc will be used.
     """
 
     def __init__(self, start_rpc, initial_request=None, metadata=None):
@@ -277,7 +278,11 @@ class BidiRpc(object):
         request_generator = _RequestQueueGenerator(
             self._request_queue, initial_request=self._initial_request
         )
-        call = self._start_rpc(iter(request_generator), metadata=self._rpc_metadata)
+        if self._rpc_metadata:
+            call = self._start_rpc(iter(request_generator), metadata=self._rpc_metadata)
+        # use metadata from self._start_rpc if no other metadata is specified
+        else:
+            call = self._start_rpc(iter(request_generator))
 
         request_generator.call = call
 


### PR DESCRIPTION
Allow Bidi to use metadata from start_rpc when no other metadata
is provided.

This allows `client_info` on wrapped client methods will be passed through to `BidiRpc`.


Fixes #202 🦕

Not expected to impact Firestore, as metadata is explicitly passed: https://github.com/googleapis/python-firestore/blob/e57258c51e4b4aa664cc927454056412756fc7ac/google/cloud/firestore_v1/watch.py#L220-L226

Pub/Sub does not seem to pass `metadata` and may be impacted: https://github.com/googleapis/python-pubsub/blob/e907f6e05f59f64a3b08df3304e92ec960997be6/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py#L523-L528