### PR TITLE
fix: add 'requests.exceptions.ChunkedEncodingError' to retryable exceptions

### DIFF
--- a/google/api_core/retry.py
+++ b/google/api_core/retry.py
@@ -104,6 +104,7 @@ if_transient_error = if_exception_type(
     exceptions.TooManyRequests,
     exceptions.ServiceUnavailable,
     requests.exceptions.ConnectionError,
+    requests.exceptions.ChunkedEncodingError,
     auth_exceptions.TransportError,
 )
 """A predicate that checks if an exception is a transient API error.

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -45,6 +45,7 @@ def test_if_transient_error():
     assert retry.if_transient_error(exceptions.TooManyRequests(""))
     assert retry.if_transient_error(exceptions.ServiceUnavailable(""))
     assert retry.if_transient_error(requests.exceptions.ConnectionError(""))
+    assert retry.if_transient_error(requests.exceptions.ChunkedEncodingError(""))
     assert retry.if_transient_error(auth_exceptions.TransportError(""))
     assert not retry.if_transient_error(exceptions.InvalidArgument(""))
 


### PR DESCRIPTION
Closes #235.
