### PR TITLE
tests: silence a warning from 'charset_normalizer'

### DIFF
--- a/google/api_core/retry.py
+++ b/google/api_core/retry.py
@@ -114,9 +114,9 @@ The following server errors are considered transient:
 - :class:`google.api_core.exceptions.TooManyRequests` - HTTP 429
 - :class:`google.api_core.exceptions.ServiceUnavailable` - HTTP 503
 - :class:`requests.exceptions.ConnectionError`
-- :class:`requests.exceptions.ChunkedEncodingError` - The server declared 
+- :class:`requests.exceptions.ChunkedEncodingError` - The server declared
     chunked encoding but sent an invalid chunk.
-- :class:`google.auth.exceptions.TransportError` - Used to indicate an 
+- :class:`google.auth.exceptions.TransportError` - Used to indicate an
     error occurred during an HTTP request.
 """
 # pylint: enable=invalid-name

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -1,0 +1,2 @@
+# Allow prerelease versions of deps
+--pre

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -1,2 +1,0 @@
-# Allow prerelease versions of deps
---pre

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -102,6 +102,7 @@ def test_from_http_response_no_content():
 
 def test_from_http_response_text_content():
     response = make_response(b"message")
+    response.encoding = "UTF8"  # suppress charset_normalizer warning
 
     exception = exceptions.from_http_response(response)
 


### PR DESCRIPTION
 'charset_normalizer', now used by 'requests' instead of 'chardet', emits warnings for very small byte-strings.