### PR TITLE
fix: strip trailing _ from field mask paths

### DIFF
--- a/google/api_core/protobuf_helpers.py
+++ b/google/api_core/protobuf_helpers.py
@@ -357,6 +357,13 @@ def _field_mask_helper(original, modified, current=""):
 
 
 def _get_path(current, name):
+    # gapic-generator-python appends underscores to field names
+    # that collide with python keywords.
+    # `_` is stripped away as it is not possible to
+    # natively define a field with a trailing underscore in protobuf.
+    # APIs will reject field masks if fields have trailing underscores.
+    # See https://github.com/googleapis/python-api-core/issues/227
+    name = name.rstrip("_")
     if not current:
         return name
     return "%s.%s" % (current, name)

--- a/noxfile.py
+++ b/noxfile.py
@@ -98,9 +98,10 @@ def default(session):
     ]
     pytest_args.extend(session.posargs)
 
-    # Inject AsyncIO content, if version >= 3.6.
+    # Inject AsyncIO content and proto-plus, if version >= 3.6.
+    # proto-plus is needed for a field mask test in test_protobuf_helpers.py
     if _greater_or_equal_than_36(session.python):
-        session.install("asyncmock", "pytest-asyncio")
+        session.install("asyncmock", "pytest-asyncio", "proto-plus")
 
         pytest_args.append("--cov=tests.asyncio")
         pytest_args.append(os.path.join("tests", "asyncio"))


### PR DESCRIPTION
Original changes is in #228. Since the master branch has already moved on to 2.0.0, I am planning on releasing this manually as 1.31.2 to PyPI.

Note: this is being merged into the `v1` branch rather than master. Since there's a small chance we might want to push additional fixes to it in the future, I've added minimal branch protection on `v1` (reviews required to merge).