### PR TITLE
chore: release 1.31.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-api-core/#history
 
+### [1.31.3](https://www.github.com/googleapis/python-api-core/compare/v1.31.2...v1.31.3) (2021-09-20)
+
+
+### Bug Fixes
+
+* fix: pin protobuf to < 3.18.0 ([#277](https://www.github.com/googleapis/python-api-core/issues/277)) ([08913ba](https://github.com/googleapis/python-api-core/commit/08913ba5b434eb47e2294e4d69423da9bd04cc6f))
+
 ### [1.31.2](https://www.github.com/googleapis/python-api-core/compare/v1.31.1...v1.31.2) (2021-08-03)
 
 

--- a/google/api_core/version.py
+++ b/google/api_core/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.31.2"
+__version__ = "1.31.3"


### PR DESCRIPTION

### Bug Fixes

* fix: pin protobuf to < 3.18.0 ([#277](https://www.github.com/googleapis/python-api-core/issues/277)) ([08913ba](https://github.com/googleapis/python-api-core/commit/08913ba5b434eb47e2294e4d69423da9bd04cc6f))