### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -8,5 +8,5 @@
     "repo": "googleapis/python-api-core",
     "distribution_name": "google-api-core",
     "default_version": "",
-    "codeowner_team": ""
+    "codeowner_team": "@googleapis/actools-python"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,10 +1,12 @@
 {
-  "name": "google-api-core",
-  "name_pretty": "Google API client core library",
-  "client_documentation": "https://googleapis.dev/python/google-api-core/latest",
-  "release_level": "ga",
-  "language": "python",
-  "library_type": "CORE",
-  "repo": "googleapis/python-api-core",
-  "distribution_name": "google-api-core"
+    "name": "google-api-core",
+    "name_pretty": "Google API client core library",
+    "client_documentation": "https://googleapis.dev/python/google-api-core/latest",
+    "release_level": "ga",
+    "language": "python",
+    "library_type": "CORE",
+    "repo": "googleapis/python-api-core",
+    "distribution_name": "google-api-core",
+    "default_version": "",
+    "codeowner_team": ""
 }


### PR DESCRIPTION
Assign `@googleapis/actools-python` as codeowner. The `default_version` is intentionally left blank. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114