### PR TITLE
fix: make 'gapic_v1.method.DEFAULT' a typed object

### DIFF
--- a/google/api_core/gapic_v1/method.py
+++ b/google/api_core/gapic_v1/method.py
@@ -18,6 +18,7 @@ This is used by gapic clients to provide common error mapping, retry, timeout,
 pagination, and long-running operations to gRPC methods.
 """
 
+import enum
 import functools
 
 from google.api_core import grpc_helpers
@@ -25,7 +26,18 @@ from google.api_core import timeout
 from google.api_core.gapic_v1 import client_info
 
 USE_DEFAULT_METADATA = object()
-DEFAULT = object()
+
+
+class _MethodDefault(enum.Enum):
+    # Uses enum so that pytype/mypy knows that this is the only possible value.
+    # https://stackoverflow.com/a/60605919/101923
+    #
+    # Literal[_DEFAULT_VALUE] is an alternative, but only added in Python 3.8.
+    # https://docs.python.org/3/library/typing.html#typing.Literal
+    _DEFAULT_VALUE = object()
+
+
+DEFAULT = _MethodDefault._DEFAULT_VALUE
 """Sentinel value indicating that a retry or timeout argument was unspecified,
 so the default should be used."""
 


### PR DESCRIPTION
FBO checkers which need to verify default values for 'retry' / 'timeout'.