### PR TITLE
feat: add support for 'error_info'

### DIFF
--- a/google/api_core/exceptions.py
+++ b/google/api_core/exceptions.py
@@ -472,8 +472,13 @@ def from_http_response(response):
     errors = payload.get("error", {}).get("errors", ())
     # In JSON, details are already formatted in developer-friendly way.
     details = payload.get("error", {}).get("details", ())
-    error_info_type = "type.googleapis.com/google.rpc.ErrorInfo"
-    error_info = [d for d in details if d.get("@type", "") == error_info_type]
+    error_info = list(
+        filter(
+            lambda detail: detail.get("@type", "")
+            == "type.googleapis.com/google.rpc.ErrorInfo",
+            details,
+        )
+    )
     error_info = error_info[0] if error_info else None
 
     message = "{method} {url}: {error}".format(

--- a/google/api_core/exceptions.py
+++ b/google/api_core/exceptions.py
@@ -104,6 +104,8 @@ class GoogleAPICallError(GoogleAPIError, metaclass=_GoogleAPICallErrorMeta):
         details (Sequence[Any]): An optional list of objects defined in google.rpc.error_details.
         response (Union[requests.Request, grpc.Call]): The response or
             gRPC call metadata.
+        error_info (Union[error_details_pb2.ErrorInfo, None]): An optional object containing error info
+            (google.rpc.error_details.ErrorInfo).
     """
 
     code: Union[int, None] = None
@@ -122,19 +124,56 @@ class GoogleAPICallError(GoogleAPIError, metaclass=_GoogleAPICallErrorMeta):
     This may be ``None`` if the exception does not match up to a gRPC error.
     """
 
-    def __init__(self, message, errors=(), details=(), response=None):
+    def __init__(self, message, errors=(), details=(), response=None, error_info=None):
         super(GoogleAPICallError, self).__init__(message)
         self.message = message
         """str: The exception message."""
         self._errors = errors
         self._details = details
         self._response = response
+        self._error_info = error_info
 
     def __str__(self):
         if self.details:
             return "{} {} {}".format(self.code, self.message, self.details)
         else:
             return "{} {}".format(self.code, self.message)
+
+    @property
+    def reason(self):
+        """The reason of the error.
+
+        Reference:
+            https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto#L112
+
+        Returns:
+            Union[str, None]: An optional string containing reason of the error.
+        """
+        return self._error_info.reason if self._error_info else None
+
+    @property
+    def domain(self):
+        """The logical grouping to which the "reason" belongs.
+
+        Reference:
+            https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto#L112
+
+        Returns:
+            Union[str, None]: An optional string containing a logical grouping to which the "reason" belongs.
+        """
+        return self._error_info.domain if self._error_info else None
+
+    @property
+    def metadata(self):
+        """Additional structured details about this error.
+
+        Reference:
+            https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto#L112
+
+        Returns:
+            Union[Dict[str, str], None]: An optional object containing structured details about the error.
+        """
+        return self._error_info.metadata if self._error_info else None
 
     @property
     def errors(self):
@@ -433,13 +472,21 @@ def from_http_response(response):
     errors = payload.get("error", {}).get("errors", ())
     # In JSON, details are already formatted in developer-friendly way.
     details = payload.get("error", {}).get("details", ())
+    error_info_type = "type.googleapis.com/google.rpc.ErrorInfo"
+    error_info = [d for d in details if d.get("@type", "") == error_info_type]
+    error_info = error_info[0] if error_info else None
 
     message = "{method} {url}: {error}".format(
-        method=response.request.method, url=response.request.url, error=error_message
+        method=response.request.method, url=response.request.url, error=error_message,
     )
 
     exception = from_http_status(
-        response.status_code, message, errors=errors, details=details, response=response
+        response.status_code,
+        message,
+        errors=errors,
+        details=details,
+        response=response,
+        error_info=error_info,
     )
     return exception
 
@@ -490,10 +537,10 @@ def _parse_grpc_error_details(rpc_exc):
     try:
         status = rpc_status.from_call(rpc_exc)
     except NotImplementedError:  # workaround
-        return []
+        return [], None
 
     if not status:
-        return []
+        return [], None
 
     possible_errors = [
         error_details_pb2.BadRequest,
@@ -507,6 +554,7 @@ def _parse_grpc_error_details(rpc_exc):
         error_details_pb2.Help,
         error_details_pb2.LocalizedMessage,
     ]
+    error_info = None
     error_details = []
     for detail in status.details:
         matched_detail_cls = list(
@@ -519,7 +567,9 @@ def _parse_grpc_error_details(rpc_exc):
             info = matched_detail_cls[0]()
             detail.Unpack(info)
         error_details.append(info)
-    return error_details
+        if isinstance(info, error_details_pb2.ErrorInfo):
+            error_info = info
+    return error_details, error_info
 
 
 def from_grpc_error(rpc_exc):
@@ -535,12 +585,14 @@ def from_grpc_error(rpc_exc):
     # NOTE(lidiz) All gRPC error shares the parent class grpc.RpcError.
     # However, check for grpc.RpcError breaks backward compatibility.
     if isinstance(rpc_exc, grpc.Call) or _is_informative_grpc_error(rpc_exc):
+        details, err_info = _parse_grpc_error_details(rpc_exc)
         return from_grpc_status(
             rpc_exc.code(),
             rpc_exc.details(),
             errors=(rpc_exc,),
-            details=_parse_grpc_error_details(rpc_exc),
+            details=details,
             response=rpc_exc,
+            error_info=err_info,
         )
     else:
         return GoogleAPICallError(str(rpc_exc), errors=(rpc_exc,), response=rpc_exc)


### PR DESCRIPTION
Adds `error_info` field to `GoogleAPICallError`, as requested in #286.

This is a duplicate of #307, except now CLA won't prevent from merging.

