### PR TITLE
fix: exclude function target from retry deadline exceeded exception message

### DIFF
--- a/google/api_core/retry.py
+++ b/google/api_core/retry.py
@@ -203,8 +203,8 @@ def retry_target(target, predicate, sleep_generator, deadline, on_error=None):
         if deadline_datetime is not None:
             if deadline_datetime <= now:
                 raise exceptions.RetryError(
-                    "Deadline of {:.1f}s exceeded while calling {}".format(
-                        deadline, target
+                    "Deadline of {:.1f}s exceeded while calling target function".format(
+                        deadline
                     ),
                     last_exc,
                 ) from last_exc

--- a/google/api_core/retry_async.py
+++ b/google/api_core/retry_async.py
@@ -132,8 +132,8 @@ async def retry_target(target, predicate, sleep_generator, deadline, on_error=No
                 # Chains the raising RetryError with the root cause error,
                 # which helps observability and debugability.
                 raise exceptions.RetryError(
-                    "Deadline of {:.1f}s exceeded while calling {}".format(
-                        deadline, target
+                    "Deadline of {:.1f}s exceeded while calling target function".format(
+                        deadline
                     ),
                     last_exc,
                 ) from last_exc

--- a/tests/asyncio/test_retry_async.py
+++ b/tests/asyncio/test_retry_async.py
@@ -120,6 +120,10 @@ async def test_retry_target_deadline_exceeded(utcnow, sleep):
     assert exc_info.match("last exception: meep")
     assert target.call_count == 2
 
+    # Ensure the exception message does not include the target fn:
+    # it may be a partial with user data embedded
+    assert str(target) not in exc_info.exconly()
+
 
 @pytest.mark.asyncio
 async def test_retry_target_bad_sleep_generator():

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -152,6 +152,10 @@ def test_retry_target_deadline_exceeded(utcnow, sleep):
     assert exc_info.match("last exception: meep")
     assert target.call_count == 2
 
+    # Ensure the exception message does not include the target fn:
+    # it may be a partial with user data embedded
+    assert str(target) not in exc_info.exconly()
+
 
 def test_retry_target_bad_sleep_generator():
     with pytest.raises(ValueError, match="Sleep generator"):


### PR DESCRIPTION
The current retry function includes a string representation of the function being retried in the exception message. For very many GCP cases, this function will be a partial with GCP API request arguments embedded, which can lead to unintentional data leaks if retry exceptions are logged. 

The proposed fix is to not log the function being retried. This is consistent with how other GCP clients behave when retries are included.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-api-core/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

