### PR TITLE
chore: release 2.3.1

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -1,3 +1,28 @@
+# https://github.com/googleapis/repo-automation-bots/tree/main/packages/sync-repo-settings
+# Rules for main branch protection
+branchProtectionRules:
+# Identifies the protection rule pattern. Name of the branch to be protected.
+# Defaults to `main`
+- pattern: main
+  requiresCodeOwnerReviews: true
+  requiresStrictStatusChecks: true
+  requiredStatusCheckContexts:
+    - 'cla/google'
+    # No Kokoro:  the following are Github actions
+    - 'lint-mypy'
+    - 'unit-3.6'
+    - 'unit-3.7'
+    - 'unit-3.8'
+    - 'unit-3.9'
+    - 'unit-3.10'
+    - 'unit_grpc_gcp-3.6'
+    - 'unit_grpc_gcp-3.7'
+    - 'unit_grpc_gcp-3.8'
+    - 'unit_grpc_gcp-3.9'
+    - 'unit_grpc_gcp-3.10'
+    - 'unit_wo_grpc-3.6'
+    - 'unit_wo_grpc-3.10'
+    - 'cover'
 permissionRules:
   - team: actools-python
     permission: admin

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -23,6 +23,26 @@ branchProtectionRules:
     - 'unit_wo_grpc-3.6'
     - 'unit_wo_grpc-3.10'
     - 'cover'
+- pattern: v2.3.1
+  requiresCodeOwnerReviews: true
+  requiresStrictStatusChecks: true
+  requiredStatusCheckContexts:
+    - 'cla/google'
+    # No Kokoro:  the following are Github actions
+    - 'lint-mypy'
+    - 'unit-3.6'
+    - 'unit-3.7'
+    - 'unit-3.8'
+    - 'unit-3.9'
+    - 'unit-3.10'
+    - 'unit_grpc_gcp-3.6'
+    - 'unit_grpc_gcp-3.7'
+    - 'unit_grpc_gcp-3.8'
+    - 'unit_grpc_gcp-3.9'
+    - 'unit_grpc_gcp-3.10'
+    - 'unit_wo_grpc-3.6'
+    - 'unit_wo_grpc-3.10'
+    - 'cover'
 permissionRules:
   - team: actools-python
     permission: admin

--- a/.github/workflows/unittest_lint.yml
+++ b/.github/workflows/unittest_lint.yml
@@ -1,0 +1,119 @@
+name: "Lint / Unit tests / Cover / Mypy"
+
+on:
+  pull_request:
+    branches:
+      - main
+
+
+jobs:
+
+  run-lint-mypy:
+    name: lint-mypy
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install nox
+
+    - name: Run lint
+      run: |
+        nox -s lint
+
+    - name: Run lint_setup_py
+      run: |
+        nox -s lint_setup_py
+
+    - name: Run mypy
+      run: |
+        nox -s mypy
+
+  run-unittests:
+    name: unit${{ matrix.option }}-${{ matrix.python }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        option: ["", "_grpc_gcp", "_wo_grpc"]
+        python:
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+        exclude:
+          - option: "_wo_grpc"
+            python: 3.7
+          - option: "_wo_grpc"
+            python: 3.8
+          - option: "_wo_grpc"
+            python: 3.9
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install nox
+
+    - name: Run unit tests
+      env:
+        COVERAGE_FILE: .coverage${{ matrix.option }}-${{matrix.python }}
+      run: |
+        nox -s unit${{ matrix.option }}-${{ matrix.python }}
+
+    - name: Upload coverage results
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage-artifacts
+        path: .coverage${{ matrix.option }}-${{ matrix.python }}
+
+  report-coverage:
+    name: cover
+    runs-on: ubuntu-latest
+    needs:
+        - run-unittests
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+
+    - name: Install coverage
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install coverage
+
+    - name: Download coverage results
+      uses: actions/download-artifact@v2
+      with:
+        name: coverage-artifacts
+        path: .coverage-results/
+
+    - name: Report coverage results
+      run: |
+        coverage combine .coverage-results/.coverage*
+        coverage report --show-missing --fail-under=100

--- a/.github/workflows/unittest_lint.yml
+++ b/.github/workflows/unittest_lint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - v2.3.1
 
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [1]: https://pypi.org/project/google-api-core/#history
 
+## [2.3.1](https://www.github.com/googleapis/python-api-core/compare/v2.3.0...v2.3.1) (2021-12-15)
+
+
+### Bug Fixes
+
+* exclude function target from retry deadline exceeded exception message ([#318](https://www.github.com/googleapis/python-api-core/issues/318)) ([34ebdcc](https://www.github.com/googleapis/python-api-core/commit/34ebdcc251d4f3d7d496e8e0b78847645a06650b))
+
+
 ## [2.3.0](https://www.github.com/googleapis/python-api-core/compare/v2.2.2...v2.3.0) (2021-11-25)
 
 

--- a/google/api_core/retry.py
+++ b/google/api_core/retry.py
@@ -203,8 +203,8 @@ def retry_target(target, predicate, sleep_generator, deadline, on_error=None):
         if deadline_datetime is not None:
             if deadline_datetime <= now:
                 raise exceptions.RetryError(
-                    "Deadline of {:.1f}s exceeded while calling {}".format(
-                        deadline, target
+                    "Deadline of {:.1f}s exceeded while calling target function".format(
+                        deadline
                     ),
                     last_exc,
                 ) from last_exc

--- a/google/api_core/retry_async.py
+++ b/google/api_core/retry_async.py
@@ -132,8 +132,8 @@ async def retry_target(target, predicate, sleep_generator, deadline, on_error=No
                 # Chains the raising RetryError with the root cause error,
                 # which helps observability and debugability.
                 raise exceptions.RetryError(
-                    "Deadline of {:.1f}s exceeded while calling {}".format(
-                        deadline, target
+                    "Deadline of {:.1f}s exceeded while calling target function".format(
+                        deadline
                     ),
                     last_exc,
                 ) from last_exc

--- a/google/api_core/version.py
+++ b/google/api_core/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"

--- a/noxfile.py
+++ b/noxfile.py
@@ -132,7 +132,7 @@ def unit(session):
     default(session)
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
 def unit_grpc_gcp(session):
     """Run the unit test suite with grpcio-gcp installed."""
     constraints_path = str(

--- a/tests/asyncio/test_retry_async.py
+++ b/tests/asyncio/test_retry_async.py
@@ -120,6 +120,10 @@ async def test_retry_target_deadline_exceeded(utcnow, sleep):
     assert exc_info.match("last exception: meep")
     assert target.call_count == 2
 
+    # Ensure the exception message does not include the target fn:
+    # it may be a partial with user data embedded
+    assert str(target) not in exc_info.exconly()
+
 
 @pytest.mark.asyncio
 async def test_retry_target_bad_sleep_generator():

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -152,6 +152,10 @@ def test_retry_target_deadline_exceeded(utcnow, sleep):
     assert exc_info.match("last exception: meep")
     assert target.call_count == 2
 
+    # Ensure the exception message does not include the target fn:
+    # it may be a partial with user data embedded
+    assert str(target) not in exc_info.exconly()
+
 
 def test_retry_target_bad_sleep_generator():
     with pytest.raises(ValueError, match="Sleep generator"):


### PR DESCRIPTION
This release PR pulls in changes from PR #287 and PR #318 since the last release [2.3.0](https://github.com/googleapis/python-api-core/releases/tag/v2.3.0) but excludes feature #315. The client libraries team is honouring a release freeze policy until January 4th, 2022. During this time we are able to release important bug fixes but regretfully we are unable to release new features until the release freeze ends on January 4th, 2022.