### PR TITLE
chore: release 1.31.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [1]: https://pypi.org/project/google-api-core/#history
 
+### [1.31.5](https://www.github.com/googleapis/python-api-core/compare/v1.31.4...v1.31.5) (2021-12-15)
+
+
+### Bug Fixes
+
+* exclude function target from retry deadline exceeded exception message ([#321](https://www.github.com/googleapis/python-api-core/issues/321)) ([34ebdcc](https://www.github.com/googleapis/python-api-core/commit/4cc4e6500e525d172a5403c8f6c4cf01fef4e66b))
+
+
 ### [1.31.4](https://www.github.com/googleapis/python-api-core/compare/v1.31.3...v1.31.4) (2021-11-08)
 
 

--- a/google/api_core/version.py
+++ b/google/api_core/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.31.4"
+__version__ = "1.31.5"


### PR DESCRIPTION
### [1.31.5](https://www.github.com/googleapis/python-api-core/compare/v1.31.4...v1.31.5) (2021-12-15)


### Bug Fixes

* exclude function target from retry deadline exceeded exception message ([#321](https://www.github.com/googleapis/python-api-core/issues/321)) ([34ebdcc](https://www.github.com/googleapis/python-api-core/commit/4cc4e6500e525d172a5403c8f6c4cf01fef4e66b))