### PR TITLE
chore: release 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+* address broken wheels in version 2.3.1
 
 ## [2.3.1](https://www.github.com/googleapis/python-api-core/compare/v2.3.0...v2.3.1) (2021-12-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 [1]: https://pypi.org/project/google-api-core/#history
 
+## [2.3.2](https://www.github.com/googleapis/python-api-core/compare/v2.3.1...v2.3.2) (2021-12-16)
+
+### Bug Fixes
+
+
 ## [2.3.1](https://www.github.com/googleapis/python-api-core/compare/v2.3.0...v2.3.1) (2021-12-15)
 
 

--- a/google/api_core/version.py
+++ b/google/api_core/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.3.1"
+__version__ = "2.3.2"


### PR DESCRIPTION
I'm going to re-release version 2.3.1 as 2.3.2 as there is an open issue the wheels are broken in version 2.3.1.

Fixes #323 🦕
