### PR TITLE
fix: remove py2 tag from wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [pytype]
 python_version = 3.6
 inputs =


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-api-core/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Universal wheels are for supporting Python 2 and 3, and adds the unnecessary `py2` tag to the wheel metadata and filename:

* `google_api_core-2.5.0-py2.py3-none-any.whl`

https://pypi.org/project/google-api-core/2.5.0/#files

https://wheel.readthedocs.io/en/stable/user_guide.html#building-wheels