### PR TITLE
feat: expose extra fields in ExtendedOperation

### DIFF
--- a/google/api_core/extended_operation.py
+++ b/google/api_core/extended_operation.py
@@ -111,6 +111,9 @@ class ExtendedOperation(polling.PollingFuture):
     def error_message(self):
         return self._extended_operation.error_message
 
+    def __getattr__(self, name):
+        return getattr(self._extended_operation, name)
+
     def done(self, retry=polling.DEFAULT_RETRY):
         self._refresh_and_update(retry)
         return self._extended_operation.done

--- a/tests/unit/test_extended_operation.py
+++ b/tests/unit/test_extended_operation.py
@@ -37,6 +37,7 @@ class CustomOperation:
     status: StatusCode
     error_code: typing.Optional[int] = None
     error_message: typing.Optional[str] = None
+    armor_class: typing.Optional[int] = None
 
     # Note: in generated clients, this property must be generated for each
     # extended operation message type.
@@ -180,3 +181,23 @@ def test_error():
 
     with pytest.raises(exceptions.GoogleAPICallError):
         ex_op.result()
+
+
+def test_pass_through():
+    responses = [
+        CustomOperation(
+            name=TEST_OPERATION_NAME,
+            status=CustomOperation.StatusCode.PENDING,
+            armor_class=10,
+        ),
+        CustomOperation(
+            name=TEST_OPERATION_NAME,
+            status=CustomOperation.StatusCode.DONE,
+            armor_class=20,
+        ),
+    ]
+    ex_op, _, _ = make_extended_operation(responses)
+
+    assert ex_op.armor_class == 10
+    ex_op.result()
+    assert ex_op.armor_class == 20


### PR DESCRIPTION
The operation wrapped by ExtendedOperation may define other fields or methods
that the user may wish to use.