### PR TITLE
fix(deps): require protobuf>= 3.15.0, <4.0.0dev

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ description = "Google API client core library"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "googleapis-common-protos >= 1.56.2, < 2.0dev",
-    "protobuf >= 3.12.0, <4.0.0dev",
+    "protobuf >= 3.15.0, <4.0.0dev",
     "google-auth >= 1.25.0, < 3.0dev",
     "requests >= 2.18.0, < 3.0.0dev",
 ]

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ description = "Google API client core library"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "googleapis-common-protos >= 1.52.0, < 2.0dev",
+    "googleapis-common-protos >= 1.56.2, < 2.0dev",
     "protobuf >= 3.12.0, <4.0.0dev",
     "google-auth >= 1.25.0, < 3.0dev",
     "requests >= 2.18.0, < 3.0.0dev",

--- a/setup.py
+++ b/setup.py
@@ -30,14 +30,14 @@ description = "Google API client core library"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "googleapis-common-protos >= 1.52.0, < 2.0dev",
-    "protobuf >= 3.12.0",
+    "protobuf >= 3.12.0, <4.0.0dev",
     "google-auth >= 1.25.0, < 3.0dev",
     "requests >= 2.18.0, < 3.0.0dev",
 ]
 extras = {
     "grpc": ["grpcio >= 1.33.2, < 2.0dev", "grpcio-status >= 1.33.2, < 2.0dev"],
-    "grpcgcp": "grpcio-gcp >= 0.2.2",
-    "grpcio-gcp": "grpcio-gcp >= 0.2.2",
+    "grpcgcp": "grpcio-gcp >= 0.2.2, < 1.0dev",
+    "grpcio-gcp": "grpcio-gcp >= 0.2.2, < 1.0dev",
 }
 
 

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -5,7 +5,7 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-googleapis-common-protos==1.52.0
+googleapis-common-protos==1.56.2
 protobuf==3.12.0
 google-auth==1.25.0
 requests==2.18.0

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -6,7 +6,7 @@
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
 googleapis-common-protos==1.56.2
-protobuf==3.12.0
+protobuf==3.15.0
 google-auth==1.25.0
 requests==2.18.0
 packaging==14.3


### PR DESCRIPTION
Also adds upper limits for extras.

fix(deps): require googleapis-common-protos >= 1.56.2