### PR TITLE
chore: test minimum dependencies in python 3.7

### DIFF
--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -1,0 +1,16 @@
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List *all* library dependencies and extras in this file.
+# Pin the version to the lower bound.
+#
+# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have foo==1.14.0
+googleapis-common-protos==1.56.2
+protobuf==3.15.0
+google-auth==1.25.0
+requests==2.18.0
+packaging==14.3
+grpcio==1.33.2
+grpcio-gcp==0.2.2
+grpcio-gcp==0.2.2
+grpcio-status==1.33.2

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -12,5 +12,4 @@ requests==2.18.0
 packaging==14.3
 grpcio==1.33.2
 grpcio-gcp==0.2.2
-grpcio-gcp==0.2.2
 grpcio-status==1.33.2


### PR DESCRIPTION
Test the minimum supported dependencies in python 3.7 unit tests to prepare for dropping python 3.6