### PR TITLE
fix: Major refactoring of Polling, Retry and Timeout logic

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.7"
+        python-version: "3.10"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.7"
+        python-version: "3.10"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/google/api_core/future/async_future.py
+++ b/google/api_core/future/async_future.py
@@ -95,7 +95,7 @@ class AsyncFuture(base.Future):
         if self._future.done():
             return
 
-        retry_ = self._retry.with_deadline(timeout)
+        retry_ = self._retry.with_timeout(timeout)
 
         try:
             await retry_(self._done_or_raise)()

--- a/google/api_core/future/polling.py
+++ b/google/api_core/future/polling.py
@@ -234,7 +234,7 @@ class PollingFuture(base.Future):
 
         Args:
             timeout (int): (Optional) How long (in seconds) to wait for the
-                operation to complete.
+                operation to complete. If None, wait indefinitely.
             retry (google.api_core.retry.Retry): (Optional) How to retry the
                 polling RPC. This defines ONLY how the polling RPC call is
                 retried (i.e. what to do if the RPC we used for polling returned

--- a/google/api_core/future/polling.py
+++ b/google/api_core/future/polling.py
@@ -18,7 +18,7 @@ import abc
 import concurrent.futures
 
 from google.api_core import exceptions
-from google.api_core import retry
+from google.api_core import retry as retries
 from google.api_core.future import _helpers
 from google.api_core.future import base
 
@@ -29,14 +29,40 @@ class _OperationNotComplete(Exception):
     pass
 
 
-RETRY_PREDICATE = retry.if_exception_type(
+# DEPRECATED as it conflates RPC retry and polling concepts into one.
+# Use POLLING_PREDICATE instead to configure polling.
+RETRY_PREDICATE = retries.if_exception_type(
     _OperationNotComplete,
     exceptions.TooManyRequests,
     exceptions.InternalServerError,
     exceptions.BadGateway,
     exceptions.ServiceUnavailable,
 )
-DEFAULT_RETRY = retry.Retry(predicate=RETRY_PREDICATE)
+
+# DEPRECATED, use DEFAULT_POLLING to configure LRO polling logic. Construct
+# Retry object using its default values as a baseline for any custom retry logic
+# (to not be confused with polling logic).
+DEFAULT_RETRY = retries.Retry(predicate=RETRY_PREDICATE)
+
+# Poling predicate is supposed to poll only on _OperationNotComplete.
+# Any RPC-specific errors (like ServiceUnavailable) will be handled
+# by retry logic (to not be confused with polling logic) which is triggered for
+# every polling RPC independently of polling logic but within its context.
+POLLING_PREDICATE = retries.if_exception_type(
+    _OperationNotComplete,
+)
+
+# Default polling configuration
+DEFAULT_POLLING = retries.Retry(
+    predicate=POLLING_PREDICATE,
+    initial=1.0,
+    maximum=20.0,
+    multiplier=1.5,
+    timeout=900,
+)
+
+# Default value used to distinguish None and Unset
+_DEFAULT_POLLING_VALUE = object()
 
 
 class PollingFuture(base.Future):
@@ -45,21 +71,29 @@ class PollingFuture(base.Future):
     The :meth:`done` method should be implemented by subclasses. The polling
     behavior will repeatedly call ``done`` until it returns True.
 
+    The actuall polling logic is encapsulated in :meth:`result` method, see
+    documentation for that method for details on how polling works.
+
     .. note::
 
         Privacy here is intended to prevent the final class from
         overexposing, not to prevent subclasses from accessing methods.
 
     Args:
-        retry (google.api_core.retry.Retry): The retry configuration used
-            when polling. This can be used to control how often :meth:`done`
-            is polled. Regardless of the retry's ``deadline``, it will be
-            overridden by the ``timeout`` argument to :meth:`result`.
+        polling (google.api_core.retry.Retry): The configuration used for polling.
+            This parameter controls how often :meth:`done` is polled. If the
+            ``timeout`` argument is specified in :meth:`result` method it will
+            override the ``polling.timeout`` property.
+        retry (google.api_core.retry.Retry): DEPRECATED use ``polling`` instead.
+            If set it will override ``polling`` paremeter for backward
+            compatibility.
     """
 
-    def __init__(self, retry=DEFAULT_RETRY):
+    _DEFAULT_VALUE = object()
+
+    def __init__(self, polling=DEFAULT_POLLING, **kwargs):
         super(PollingFuture, self).__init__()
-        self._retry = retry
+        self._polling = kwargs.get("retry", polling)
         self._result = None
         self._exception = None
         self._result_set = False
@@ -69,11 +103,13 @@ class PollingFuture(base.Future):
         self._done_callbacks = []
 
     @abc.abstractmethod
-    def done(self, retry=DEFAULT_RETRY):
+    def done(self, retry=None):
         """Checks to see if the operation is complete.
 
         Args:
-            retry (google.api_core.retry.Retry): (Optional) How to retry the RPC.
+            retry (google.api_core.retry.Retry): (Optional) How to retry the
+            polling RPC (to not be confused with polling configuration, see
+            the documentation for :meth:`result` for details).
 
         Returns:
             bool: True if the operation is complete, False otherwise.
@@ -81,45 +117,134 @@ class PollingFuture(base.Future):
         # pylint: disable=redundant-returns-doc, missing-raises-doc
         raise NotImplementedError()
 
-    def _done_or_raise(self, retry=DEFAULT_RETRY):
+    def _done_or_raise(self, retry=None):
         """Check if the future is done and raise if it's not."""
-        kwargs = {} if retry is DEFAULT_RETRY else {"retry": retry}
-
-        if not self.done(**kwargs):
+        if not self.done(retry=retry):
             raise _OperationNotComplete()
 
     def running(self):
         """True if the operation is currently running."""
         return not self.done()
 
-    def _blocking_poll(self, timeout=None, retry=DEFAULT_RETRY):
-        """Poll and wait for the Future to be resolved.
-
-        Args:
-            timeout (int):
-                How long (in seconds) to wait for the operation to complete.
-                If None, wait indefinitely.
-        """
+    def _blocking_poll(self, timeout=_DEFAULT_VALUE, retry=None, polling=None):
+        """Poll and wait for the Future to be resolved."""
         if self._result_set:
             return
 
-        retry_ = self._retry.with_deadline(timeout)
+        polling = polling or self._polling
+        if timeout is not PollingFuture._DEFAULT_VALUE:
+            polling = polling.with_timeout(timeout)
 
         try:
-            kwargs = {} if retry is DEFAULT_RETRY else {"retry": retry}
-            retry_(self._done_or_raise)(**kwargs)
+            polling(self._done_or_raise)(retry=retry)
         except exceptions.RetryError:
             raise concurrent.futures.TimeoutError(
-                "Operation did not complete within the designated " "timeout."
+                "Operation did not complete within the designated timeout."
             )
 
-    def result(self, timeout=None, retry=DEFAULT_RETRY):
-        """Get the result of the operation, blocking if necessary.
+    def result(self, timeout=_DEFAULT_VALUE, retry=None, polling=None):
+        """Get the result of the operation.
+
+        This method will poll for operation status periodically, blocking if
+        necessary. If you just want to make sure that this method does not block
+        for more than X seconds and you do not care about the nitty-gritty of
+        how this  method operates, just call it with ``result(timeout=X)``. The
+        other parameters are for advanced use only.
+
+        Every call to this method is controlled by the following three
+        parameters each of which has a specific distinct role although all three
+        may look very similar: ``timeout``, ``retry`` and ``polling``. In most
+        cases users do not need to specify any custom values for any of these
+        parameters and rely on default ones instead.
+
+        If you choose to specify your custom parameters, please make sure you've
+        read the documentation below carefully.
+
+        First please check :class:`google.api_core.retry.Retry`
+        class documentation for the proper definition of timeout and deadline
+        terms and for the definition the three different types of timeouts.
+        This class operates in terms of Retry Timeot and Polling Timeout, it
+        does let customizing RPC timeout and a user is expected to rely on
+        default behavior for it.
+
+        The roles of each argument of this method are as follows:
+
+        ``timeout`` (int): (Optional) The Polling Timeout as defined in
+        :class:`google.api_core.retry.Retry`. If the operation does not complete
+        within this timeout an exception will be thrown. This parameter affects
+        neither Retry Timeout nor RPC Timeout.
+
+        ``retry`` (google.api_core.retry.Retry): (Optional) How to retry the
+        polling RPC. The ``retry.timeout`` propery of this parameter is the
+        Retry Timeout as defined in :class:`google.api_core.retry.Retry`.
+        This parameter defines ONLY how the polling RPC call is retried
+        (i.e. what to do if the RPC we used for polling returned an error), it
+        does  NOT define how the polling is done (i.e. how frequently and for
+        how long to call the polling RPC - use ``polling`` parameter for that).
+        If a polling RPC throws and error and retrying it fails, the whole
+        future fails with the corresponding exception. If you want to tune which
+        server response error codes are not fatal for operation polling use this
+        parameter to control that (``retry.predicate`` in particular).
+
+        ``polling`` (google.api_core.retry.Retry): (Optional) How often and
+        for how long to call the polling RPC periodically (i.e. what to do if
+        a polling rpc returned successfully but its returned result indicates
+        that the long running operaiton is not completed yet, so we need to
+        check it again at some point in future). This parameter does NOT define
+        how to retry each individual polling RPC in case of an error (use the
+        ``retry`` parameter for that). The ``polling.timeout`` of this parameter
+        is Polling Timeout as defined in as defined in
+        :class:`google.api_core.retry.Retry`.
+
+        For each of the arguments there are also default values in place, which
+        will be used if a user does not specify their own. The default values
+        for the three parameters are not to be confused with the default values
+        for the corresponding arguments in this method (those serve as "not set"
+        markers for the resoluiton logic).
+
+        If ``timeout`` is provided (i.e.``timeout is not _DEFAULT VALUE``, note
+        the `None` value means "infinite timeout") it will be used to control
+        the actual Polling Timeout. Otherwise, ``polling.timeout`` value
+        will be used instead (see below for how the ``polling`` config itself
+        gets resolved). In other words this parameter  effectively overrides
+        the ``polling.timeout`` value if specified. This is so to preserve
+        backward compatibility.
+
+        If ``retry`` is provided (i.e. ``retry is not None``) it will be used to
+        control retry behavior for the polling RPC and the ``retry.timeout``
+        will determine the Retry Timeout. If not provided, the
+        polling RPC will be called with whichever default retry config was
+        specified for the polling RPC at the moment of the construction of the
+        polling RPC's client. For example, if the polling RPC is
+        `operations_client.get_operation()`  the ``retry`` parameter will be
+        controlling its retry behavior (not polling  behavior) and, if not
+        specified, that specific method (``operations_client.get_operation()``)
+        will be retried according to the default retry config provided during
+        creation of ``operations_client`` client instead. This argument exists
+        mainly for backward compatibility, users are very unlikely to ever need
+        to set this parameter explicitly.
+
+        If ``polling`` is provided (i.e. ``polling is not None``) it will be used
+        to controll the overall polling behavior and ``polling.timeout`` will
+        controll Polling Timeout unless it is overridden by ``timeout`` parameter
+        as described above. If not provided the``polling`` parameter specified
+        during construction of this future (the ``polling`` argument in the
+        constructor) will be used instead. Note, since ``timeout`` argument may
+        override ``polling.timeout`` value, this parameter should be viewed as
+        coupled with the ``timeout`` parameter as described above.
 
         Args:
-            timeout (int):
-                How long (in seconds) to wait for the operation to complete.
-                If None, wait indefinitely.
+            timeout (int): (Optional) How long (in seconds) to wait for the
+                operation to complete.
+            retry (google.api_core.retry.Retry): (Optional) How to retry the
+                polling RPC. This defines ONLY how the polling RPC call is
+                retried (i.e. what to do if the RPC we used for polling returned
+                an error), it does  NOT define how the polling is done (i.e. how
+                frequently and for how long to call the polling RPC).
+            polling (google.api_core.retry.Retry): (Optional) How often and
+                for how long to call polling RPC periodically. This parameter
+                does NOT define how to retry each individual polling RPC call
+                (use the ``retry`` parameter for that).
 
         Returns:
             google.protobuf.Message: The Operation's result.
@@ -128,8 +253,8 @@ class PollingFuture(base.Future):
             google.api_core.GoogleAPICallError: If the operation errors or if
                 the timeout is reached before the operation completes.
         """
-        kwargs = {} if retry is DEFAULT_RETRY else {"retry": retry}
-        self._blocking_poll(timeout=timeout, **kwargs)
+
+        self._blocking_poll(timeout=timeout, retry=retry, polling=polling)
 
         if self._exception is not None:
             # pylint: disable=raising-bad-type
@@ -138,12 +263,18 @@ class PollingFuture(base.Future):
 
         return self._result
 
-    def exception(self, timeout=None):
+    def exception(self, timeout=_DEFAULT_VALUE):
         """Get the exception from the operation, blocking if necessary.
+
+        See the documentation for the :meth:`result` method for details on how
+        this method operates, as both ``result`` and this method rely on the
+        exact same polling logic. The only difference is that this method does
+        not accept ``retry`` and ``polling`` arguments but relies on defaul ones
+        instead.
 
         Args:
             timeout (int): How long to wait for the operation to complete.
-                If None, wait indefinitely.
+            If None, wait indefinitely.
 
         Returns:
             Optional[google.api_core.GoogleAPICallError]: The operation's

--- a/google/api_core/future/polling.py
+++ b/google/api_core/future/polling.py
@@ -55,10 +55,10 @@ POLLING_PREDICATE = retries.if_exception_type(
 # Default polling configuration
 DEFAULT_POLLING = retries.Retry(
     predicate=POLLING_PREDICATE,
-    initial=1.0,
-    maximum=20.0,
+    initial=1.0,  # seconds
+    maximum=20.0,  # seconds
     multiplier=1.5,
-    timeout=900,
+    timeout=900,  # seconds
 )
 
 
@@ -137,7 +137,8 @@ class PollingFuture(base.Future):
             polling(self._done_or_raise)(retry=retry)
         except exceptions.RetryError:
             raise concurrent.futures.TimeoutError(
-                "Operation did not complete within the designated timeout."
+                f"Operation did not complete within the designated timeout of "
+                f"{polling.timeout} seconds."
             )
 
     def result(self, timeout=_DEFAULT_VALUE, retry=None, polling=None):

--- a/google/api_core/future/polling.py
+++ b/google/api_core/future/polling.py
@@ -39,14 +39,14 @@ RETRY_PREDICATE = retries.if_exception_type(
     exceptions.ServiceUnavailable,
 )
 
-# DEPRECATED, use DEFAULT_POLLING to configure LRO polling logic. Construct
+# DEPRECATED: use DEFAULT_POLLING to configure LRO polling logic. Construct
 # Retry object using its default values as a baseline for any custom retry logic
-# (to not be confused with polling logic).
+# (not to be confused with polling logic).
 DEFAULT_RETRY = retries.Retry(predicate=RETRY_PREDICATE)
 
-# Polling predicate is supposed to poll only on _OperationNotComplete.
+# POLLING_PREDICATE is supposed to poll only on _OperationNotComplete.
 # Any RPC-specific errors (like ServiceUnavailable) will be handled
-# by retry logic (to not be confused with polling logic) which is triggered for
+# by retry logic (not to be confused with polling logic) which is triggered for
 # every polling RPC independently of polling logic but within its context.
 POLLING_PREDICATE = retries.if_exception_type(
     _OperationNotComplete,
@@ -68,7 +68,7 @@ class PollingFuture(base.Future):
     The :meth:`done` method should be implemented by subclasses. The polling
     behavior will repeatedly call ``done`` until it returns True.
 
-    The actuall polling logic is encapsulated in :meth:`result` method, see
+    The actuall polling logic is encapsulated in :meth:`result` method. See
     documentation for that method for details on how polling works.
 
     .. note::
@@ -82,7 +82,7 @@ class PollingFuture(base.Future):
             ``timeout`` argument is specified in :meth:`result` method it will
             override the ``polling.timeout`` property.
         retry (google.api_core.retry.Retry): DEPRECATED use ``polling`` instead.
-            If set it will override ``polling`` paremeter for backward
+            If set, it will override ``polling`` paremeter for backward
             compatibility.
     """
 
@@ -147,23 +147,23 @@ class PollingFuture(base.Future):
         This method will poll for operation status periodically, blocking if
         necessary. If you just want to make sure that this method does not block
         for more than X seconds and you do not care about the nitty-gritty of
-        how this  method operates, just call it with ``result(timeout=X)``. The
+        how this method operates, just call it with ``result(timeout=X)``. The
         other parameters are for advanced use only.
 
         Every call to this method is controlled by the following three
-        parameters each of which has a specific distinct role although all three
+        parameters, each of which has a specific, distinct role, even though all three
         may look very similar: ``timeout``, ``retry`` and ``polling``. In most
         cases users do not need to specify any custom values for any of these
-        parameters and rely on default ones instead.
+        parameters and may simply rely on default ones instead.
 
-        If you choose to specify your custom parameters, please make sure you've
+        If you choose to specify custom parameters, please make sure you've
         read the documentation below carefully.
 
-        First please check :class:`google.api_core.retry.Retry`
+        First, please check :class:`google.api_core.retry.Retry`
         class documentation for the proper definition of timeout and deadline
         terms and for the definition the three different types of timeouts.
-        This class operates in terms of Retry Timeot and Polling Timeout, it
-        does let customizing RPC timeout and a user is expected to rely on
+        This class operates in terms of Retry Timeout and Polling Timeout. It
+        does not let customizing RPC timeout and the user is expected to rely on
         default behavior for it.
 
         The roles of each argument of this method are as follows:
@@ -174,38 +174,38 @@ class PollingFuture(base.Future):
         neither Retry Timeout nor RPC Timeout.
 
         ``retry`` (google.api_core.retry.Retry): (Optional) How to retry the
-        polling RPC. The ``retry.timeout`` propery of this parameter is the
+        polling RPC. The ``retry.timeout`` property of this parameter is the
         Retry Timeout as defined in :class:`google.api_core.retry.Retry`.
         This parameter defines ONLY how the polling RPC call is retried
-        (i.e. what to do if the RPC we used for polling returned an error), it
-        does  NOT define how the polling is done (i.e. how frequently and for
-        how long to call the polling RPC - use ``polling`` parameter for that).
+        (i.e. what to do if the RPC we used for polling returned an error). It
+        does NOT define how the polling is done (i.e. how frequently and for
+        how long to call the polling RPC); use the ``polling`` parameter for that.
         If a polling RPC throws and error and retrying it fails, the whole
         future fails with the corresponding exception. If you want to tune which
-        server response error codes are not fatal for operation polling use this
+        server response error codes are not fatal for operation polling, use this
         parameter to control that (``retry.predicate`` in particular).
 
         ``polling`` (google.api_core.retry.Retry): (Optional) How often and
         for how long to call the polling RPC periodically (i.e. what to do if
         a polling rpc returned successfully but its returned result indicates
-        that the long running operaiton is not completed yet, so we need to
+        that the long running operation is not completed yet, so we need to
         check it again at some point in future). This parameter does NOT define
-        how to retry each individual polling RPC in case of an error (use the
-        ``retry`` parameter for that). The ``polling.timeout`` of this parameter
+        how to retry each individual polling RPC in case of an error; use the
+        ``retry`` parameter for that. The ``polling.timeout`` of this parameter
         is Polling Timeout as defined in as defined in
         :class:`google.api_core.retry.Retry`.
 
-        For each of the arguments there are also default values in place, which
+        For each of the arguments, there are also default values in place, which
         will be used if a user does not specify their own. The default values
         for the three parameters are not to be confused with the default values
         for the corresponding arguments in this method (those serve as "not set"
-        markers for the resoluiton logic).
+        markers for the resolution logic).
 
-        If ``timeout`` is provided (i.e.``timeout is not _DEFAULT VALUE``, note
-        the `None` value means "infinite timeout") it will be used to control
-        the actual Polling Timeout. Otherwise, ``polling.timeout`` value
+        If ``timeout`` is provided (i.e.``timeout is not _DEFAULT VALUE``; note
+        the ``None`` value means "infinite timeout"), it will be used to control
+        the actual Polling Timeout. Otherwise, the ``polling.timeout`` value
         will be used instead (see below for how the ``polling`` config itself
-        gets resolved). In other words this parameter  effectively overrides
+        gets resolved). In other words, this parameter  effectively overrides
         the ``polling.timeout`` value if specified. This is so to preserve
         backward compatibility.
 
@@ -215,20 +215,20 @@ class PollingFuture(base.Future):
         polling RPC will be called with whichever default retry config was
         specified for the polling RPC at the moment of the construction of the
         polling RPC's client. For example, if the polling RPC is
-        `operations_client.get_operation()`  the ``retry`` parameter will be
+        ``operations_client.get_operation()``, the ``retry`` parameter will be
         controlling its retry behavior (not polling  behavior) and, if not
         specified, that specific method (``operations_client.get_operation()``)
         will be retried according to the default retry config provided during
         creation of ``operations_client`` client instead. This argument exists
-        mainly for backward compatibility, users are very unlikely to ever need
+        mainly for backward compatibility; users are very unlikely to ever need
         to set this parameter explicitly.
 
-        If ``polling`` is provided (i.e. ``polling is not None``) it will be used
+        If ``polling`` is provided (i.e. ``polling is not None``), it will be used
         to controll the overall polling behavior and ``polling.timeout`` will
         controll Polling Timeout unless it is overridden by ``timeout`` parameter
-        as described above. If not provided the``polling`` parameter specified
+        as described above. If not provided, the``polling`` parameter specified
         during construction of this future (the ``polling`` argument in the
-        constructor) will be used instead. Note, since ``timeout`` argument may
+        constructor) will be used instead. Note: since the ``timeout`` argument may
         override ``polling.timeout`` value, this parameter should be viewed as
         coupled with the ``timeout`` parameter as described above.
 
@@ -238,7 +238,7 @@ class PollingFuture(base.Future):
             retry (google.api_core.retry.Retry): (Optional) How to retry the
                 polling RPC. This defines ONLY how the polling RPC call is
                 retried (i.e. what to do if the RPC we used for polling returned
-                an error), it does  NOT define how the polling is done (i.e. how
+                an error). It does  NOT define how the polling is done (i.e. how
                 frequently and for how long to call the polling RPC).
             polling (google.api_core.retry.Retry): (Optional) How often and
                 for how long to call polling RPC periodically. This parameter
@@ -268,7 +268,7 @@ class PollingFuture(base.Future):
         See the documentation for the :meth:`result` method for details on how
         this method operates, as both ``result`` and this method rely on the
         exact same polling logic. The only difference is that this method does
-        not accept ``retry`` and ``polling`` arguments but relies on defaul ones
+        not accept ``retry`` and ``polling`` arguments but relies on the default ones
         instead.
 
         Args:

--- a/google/api_core/future/polling.py
+++ b/google/api_core/future/polling.py
@@ -61,9 +61,6 @@ DEFAULT_POLLING = retries.Retry(
     timeout=900,
 )
 
-# Default value used to distinguish None and Unset
-_DEFAULT_POLLING_VALUE = object()
-
 
 class PollingFuture(base.Future):
     """A Future that needs to poll some service to check its status.

--- a/google/api_core/future/polling.py
+++ b/google/api_core/future/polling.py
@@ -108,8 +108,8 @@ class PollingFuture(base.Future):
 
         Args:
             retry (google.api_core.retry.Retry): (Optional) How to retry the
-            polling RPC (to not be confused with polling configuration, see
-            the documentation for :meth:`result` for details).
+                polling RPC (to not be confused with polling configuration, see
+                the documentation for :meth:`result` for details).
 
         Returns:
             bool: True if the operation is complete, False otherwise.
@@ -128,6 +128,7 @@ class PollingFuture(base.Future):
 
     def _blocking_poll(self, timeout=_DEFAULT_VALUE, retry=None, polling=None):
         """Poll and wait for the Future to be resolved."""
+
         if self._result_set:
             return
 

--- a/google/api_core/future/polling.py
+++ b/google/api_core/future/polling.py
@@ -44,7 +44,7 @@ RETRY_PREDICATE = retries.if_exception_type(
 # (to not be confused with polling logic).
 DEFAULT_RETRY = retries.Retry(predicate=RETRY_PREDICATE)
 
-# Poling predicate is supposed to poll only on _OperationNotComplete.
+# Polling predicate is supposed to poll only on _OperationNotComplete.
 # Any RPC-specific errors (like ServiceUnavailable) will be handled
 # by retry logic (to not be confused with polling logic) which is triggered for
 # every polling RPC independently of polling logic but within its context.

--- a/google/api_core/future/polling.py
+++ b/google/api_core/future/polling.py
@@ -105,7 +105,7 @@ class PollingFuture(base.Future):
 
         Args:
             retry (google.api_core.retry.Retry): (Optional) How to retry the
-                polling RPC (to not be confused with polling configuration, see
+                polling RPC (to not be confused with polling configuration. See
                 the documentation for :meth:`result` for details).
 
         Returns:

--- a/google/api_core/gapic_v1/config.py
+++ b/google/api_core/gapic_v1/config.py
@@ -33,6 +33,9 @@ _MILLIS_PER_SECOND = 1000.0
 def _exception_class_for_grpc_status_name(name):
     """Returns the Google API exception class for a gRPC error code name.
 
+    DEPRECATED use ``exceptions.exception_class_for_grpc_status`` method
+    directly instead.
+
     Args:
         name (str): The name of the gRPC status code, for example,
             ``UNAVAILABLE``.
@@ -46,6 +49,8 @@ def _exception_class_for_grpc_status_name(name):
 
 def _retry_from_retry_config(retry_params, retry_codes, retry_impl=retry.Retry):
     """Creates a Retry object given a gapic retry configuration.
+
+    DEPRECATED instantiate retry and timeout classes directly instead.
 
     Args:
         retry_params (dict): The retry parameter values, for example::
@@ -81,6 +86,8 @@ def _retry_from_retry_config(retry_params, retry_codes, retry_impl=retry.Retry):
 def _timeout_from_retry_config(retry_params):
     """Creates a ExponentialTimeout object given a gapic retry configuration.
 
+    DEPRECATED instantiate retry and timeout classes directly instead.
+
     Args:
         retry_params (dict): The retry parameter values, for example::
 
@@ -112,6 +119,8 @@ MethodConfig = collections.namedtuple("MethodConfig", ["retry", "timeout"])
 def parse_method_configs(interface_config, retry_impl=retry.Retry):
     """Creates default retry and timeout objects for each method in a gapic
     interface config.
+
+    DEPRECATED instantiate retry and timeout classes directly instead.
 
     Args:
         interface_config (Mapping): The interface config section of the full

--- a/google/api_core/gapic_v1/config.py
+++ b/google/api_core/gapic_v1/config.py
@@ -33,7 +33,7 @@ _MILLIS_PER_SECOND = 1000.0
 def _exception_class_for_grpc_status_name(name):
     """Returns the Google API exception class for a gRPC error code name.
 
-    DEPRECATED use ``exceptions.exception_class_for_grpc_status`` method
+    DEPRECATED: use ``exceptions.exception_class_for_grpc_status`` method
     directly instead.
 
     Args:
@@ -50,7 +50,7 @@ def _exception_class_for_grpc_status_name(name):
 def _retry_from_retry_config(retry_params, retry_codes, retry_impl=retry.Retry):
     """Creates a Retry object given a gapic retry configuration.
 
-    DEPRECATED instantiate retry and timeout classes directly instead.
+    DEPRECATED: instantiate retry and timeout classes directly instead.
 
     Args:
         retry_params (dict): The retry parameter values, for example::
@@ -86,7 +86,7 @@ def _retry_from_retry_config(retry_params, retry_codes, retry_impl=retry.Retry):
 def _timeout_from_retry_config(retry_params):
     """Creates a ExponentialTimeout object given a gapic retry configuration.
 
-    DEPRECATED instantiate retry and timeout classes directly instead.
+    DEPRECATED: instantiate retry and timeout classes directly instead.
 
     Args:
         retry_params (dict): The retry parameter values, for example::
@@ -120,7 +120,7 @@ def parse_method_configs(interface_config, retry_impl=retry.Retry):
     """Creates default retry and timeout objects for each method in a gapic
     interface config.
 
-    DEPRECATED instantiate retry and timeout classes directly instead.
+    DEPRECATED: instantiate retry and timeout classes directly instead.
 
     Args:
         interface_config (Mapping): The interface config section of the full

--- a/google/api_core/gapic_v1/method.py
+++ b/google/api_core/gapic_v1/method.py
@@ -71,7 +71,7 @@ class _GapicCallable(object):
             callable (i.e. duration of time within which an RPC must terminate
             after its start, not to be confused with deadline). If ``None``,
             this callable will not specify a timeout argument to the low-level
-            RPC method by default.
+            RPC method.
         metadata (Sequence[Tuple[str, str]]): Additional metadata that is
             provided to the RPC method on every invocation. This is merged with
             any metadata specified during invocation. If ``None``, no

--- a/google/api_core/gapic_v1/method.py
+++ b/google/api_core/gapic_v1/method.py
@@ -22,8 +22,8 @@ import enum
 import functools
 
 from google.api_core import grpc_helpers
-from google.api_core import timeout
 from google.api_core.gapic_v1 import client_info
+from google.api_core.timeout import TimeToDeadlineTimeout
 
 USE_DEFAULT_METADATA = object()
 
@@ -52,53 +52,12 @@ def _apply_decorators(func, decorators):
     ``decorators`` may contain items that are ``None`` or ``False`` which will
     be ignored.
     """
-    decorators = filter(_is_not_none_or_false, reversed(decorators))
+    filtered_decorators = filter(_is_not_none_or_false, reversed(decorators))
 
-    for decorator in decorators:
+    for decorator in filtered_decorators:
         func = decorator(func)
 
     return func
-
-
-def _determine_timeout(default_timeout, specified_timeout, retry):
-    """Determines how timeout should be applied to a wrapped method.
-
-    Args:
-        default_timeout (Optional[Timeout]): The default timeout specified
-            at method creation time.
-        specified_timeout (Optional[Timeout]): The timeout specified at
-            invocation time. If :attr:`DEFAULT`, this will be set to
-            the ``default_timeout``.
-        retry (Optional[Retry]): The retry specified at invocation time.
-
-    Returns:
-        Optional[Timeout]: The timeout to apply to the method or ``None``.
-    """
-    # If timeout is specified as a number instead of a Timeout instance,
-    # convert it to a ConstantTimeout.
-    if isinstance(specified_timeout, (int, float)):
-        specified_timeout = timeout.ConstantTimeout(specified_timeout)
-    if isinstance(default_timeout, (int, float)):
-        default_timeout = timeout.ConstantTimeout(default_timeout)
-
-    if specified_timeout is DEFAULT:
-        specified_timeout = default_timeout
-
-    if specified_timeout is default_timeout:
-        # If timeout is the default and the default timeout is exponential and
-        # a non-default retry is specified, make sure the timeout's deadline
-        # matches the retry's. This handles the case where the user leaves
-        # the timeout default but specifies a lower deadline via the retry.
-        if (
-            retry
-            and retry is not DEFAULT
-            and isinstance(default_timeout, timeout.ExponentialTimeout)
-        ):
-            return default_timeout.with_deadline(retry._deadline)
-        else:
-            return default_timeout
-
-    return specified_timeout
 
 
 class _GapicCallable(object):
@@ -108,9 +67,11 @@ class _GapicCallable(object):
         target (Callable): The low-level RPC method.
         retry (google.api_core.retry.Retry): The default retry for the
             callable. If ``None``, this callable will not retry by default
-        timeout (google.api_core.timeout.Timeout): The default timeout
-            for the callable. If ``None``, this callable will not specify
-            a timeout argument to the low-level RPC method by default.
+        timeout (google.api_core.timeout.Timeout): The default timeout for the
+            callable (i.e. duration of time within which an RPC must terminate
+            after its start, to not be confused with deadline). If ``None``,
+            this callable will not specify a timeout argument to the low-level
+            RPC method by default.
         metadata (Sequence[Tuple[str, str]]): Additional metadata that is
             provided to the RPC method on every invocation. This is merged with
             any metadata specified during invocation. If ``None``, no
@@ -125,17 +86,15 @@ class _GapicCallable(object):
 
     def __call__(self, *args, timeout=DEFAULT, retry=DEFAULT, **kwargs):
         """Invoke the low-level RPC with retry, timeout, and metadata."""
-        timeout = _determine_timeout(
-            self._timeout,
-            timeout,
-            # Use only the invocation-specified retry only for this, as we only
-            # want to adjust the timeout deadline if the *user* specified
-            # a different retry.
-            retry,
-        )
 
         if retry is DEFAULT:
             retry = self._retry
+
+        if timeout is DEFAULT:
+            timeout = self._timeout
+
+        if isinstance(timeout, (int, float)):
+            timeout = TimeToDeadlineTimeout(timeout=timeout)
 
         # Apply all applicable decorators.
         wrapped_func = _apply_decorators(self._target, [retry, timeout])

--- a/google/api_core/gapic_v1/method.py
+++ b/google/api_core/gapic_v1/method.py
@@ -69,7 +69,7 @@ class _GapicCallable(object):
             callable. If ``None``, this callable will not retry by default
         timeout (google.api_core.timeout.Timeout): The default timeout for the
             callable (i.e. duration of time within which an RPC must terminate
-            after its start, to not be confused with deadline). If ``None``,
+            after its start, not to be confused with deadline). If ``None``,
             this callable will not specify a timeout argument to the low-level
             RPC method by default.
         metadata (Sequence[Tuple[str, str]]): Additional metadata that is

--- a/google/api_core/grpc_helpers.py
+++ b/google/api_core/grpc_helpers.py
@@ -30,7 +30,7 @@ import google.protobuf
 PROTOBUF_VERSION = google.protobuf.__version__
 
 # The grpcio-gcp package only has support for protobuf < 4
-if PROTOBUF_VERSION[0:2] == "3.":
+if PROTOBUF_VERSION[0:2] == "3.":  # pragma: NO COVER
     try:
         import grpc_gcp
 
@@ -318,7 +318,7 @@ def create_channel(
         default_host=default_host,
     )
 
-    if HAS_GRPC_GCP:
+    if HAS_GRPC_GCP:  # pragma: NO COVER
         return grpc_gcp.secure_channel(target, composite_credentials, **kwargs)
     return grpc.secure_channel(target, composite_credentials, **kwargs)
 

--- a/google/api_core/operation.py
+++ b/google/api_core/operation.py
@@ -63,9 +63,9 @@ class Operation(polling.PollingFuture):
             metadata.
         polling (google.api_core.retry.Retry): The configuration used for polling.
             This parameter controls how often :meth:`done` is polled. If the
-            ``timeout`` argument is specified in :meth:`result` method it will
+            ``timeout`` argument is specified in the :meth:`result` method, it will
             override the ``polling.timeout`` property.
-        retry (google.api_core.retry.Retry): DEPRECATED use ``polling`` instead.
+        retry (google.api_core.retry.Retry): DEPRECATED: use ``polling`` instead.
             If specified it will override ``polling`` parameter to maintain
             backward compatibility.
     """

--- a/google/api_core/operation.py
+++ b/google/api_core/operation.py
@@ -61,10 +61,13 @@ class Operation(polling.PollingFuture):
             result.
         metadata_type (func:`type`): The protobuf type for the operation's
             metadata.
-        retry (google.api_core.retry.Retry): The retry configuration used
-            when polling. This can be used to control how often :meth:`done`
-            is polled. Regardless of the retry's ``deadline``, it will be
-            overridden by the ``timeout`` argument to :meth:`result`.
+        polling (google.api_core.retry.Retry): The configuration used for polling.
+            This parameter controls how often :meth:`done` is polled. If the
+            ``timeout`` argument is specified in :meth:`result` method it will
+            override the ``polling.timeout`` property.
+        retry (google.api_core.retry.Retry): DEPRECATED use ``polling`` instead.
+            If specified it will override ``polling`` parameter to maintain
+            backward compatibility.
     """
 
     def __init__(
@@ -74,9 +77,10 @@ class Operation(polling.PollingFuture):
         cancel,
         result_type,
         metadata_type=None,
-        retry=polling.DEFAULT_RETRY,
+        polling=polling.DEFAULT_POLLING,
+        **kwargs
     ):
-        super(Operation, self).__init__(retry=retry)
+        super(Operation, self).__init__(polling=polling, **kwargs)
         self._operation = operation
         self._refresh = refresh
         self._cancel = cancel
@@ -146,7 +150,7 @@ class Operation(polling.PollingFuture):
                 )
                 self.set_exception(exception)
 
-    def _refresh_and_update(self, retry=polling.DEFAULT_RETRY):
+    def _refresh_and_update(self, retry=None):
         """Refresh the operation and update the result if needed.
 
         Args:
@@ -155,10 +159,10 @@ class Operation(polling.PollingFuture):
         # If the currently cached operation is done, no need to make another
         # RPC as it will not change once done.
         if not self._operation.done:
-            self._operation = self._refresh(retry=retry)
+            self._operation = self._refresh(retry=retry) if retry else self._refresh()
             self._set_result_from_operation()
 
-    def done(self, retry=polling.DEFAULT_RETRY):
+    def done(self, retry=None):
         """Checks to see if the operation is complete.
 
         Args:

--- a/google/api_core/operations_v1/operations_async_client.py
+++ b/google/api_core/operations_v1/operations_async_client.py
@@ -24,8 +24,10 @@
 
 import functools
 
+from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1, page_iterator_async
-from google.api_core.operations_v1 import operations_client_config
+from google.api_core import retry as retries
+from google.api_core import timeout as timeouts
 from google.longrunning import operations_pb2
 
 
@@ -41,39 +43,44 @@ class OperationsAsyncClient:
             the default configuration is used.
     """
 
-    def __init__(self, channel, client_config=operations_client_config.config):
+    def __init__(self, channel, client_config=None):
         # Create the gRPC client stub with gRPC AsyncIO channel.
         self.operations_stub = operations_pb2.OperationsStub(channel)
 
-        # Create all wrapped methods using the interface configuration.
-        # The interface config contains all of the default settings for retry
-        # and timeout for each RPC method.
-        interfaces = client_config["interfaces"]
-        interface_config = interfaces["google.longrunning.Operations"]
-        method_configs = gapic_v1.config_async.parse_method_configs(interface_config)
+        default_retry = retries.Retry(
+            initial=0.1,
+            maximum=60.0,
+            multiplier=1.3,
+            predicate=retries.if_exception_type(
+                core_exceptions.DeadlineExceeded,
+                core_exceptions.ServiceUnavailable,
+            ),
+            timeout=600.0,
+        )
+        default_timeout = timeouts.TimeToDeadlineTimeout(timeout=600.0)
 
         self._get_operation = gapic_v1.method_async.wrap_method(
             self.operations_stub.GetOperation,
-            default_retry=method_configs["GetOperation"].retry,
-            default_timeout=method_configs["GetOperation"].timeout,
+            default_retry=default_retry,
+            default_timeout=default_timeout,
         )
 
         self._list_operations = gapic_v1.method_async.wrap_method(
             self.operations_stub.ListOperations,
-            default_retry=method_configs["ListOperations"].retry,
-            default_timeout=method_configs["ListOperations"].timeout,
+            default_retry=default_retry,
+            default_timeout=default_timeout,
         )
 
         self._cancel_operation = gapic_v1.method_async.wrap_method(
             self.operations_stub.CancelOperation,
-            default_retry=method_configs["CancelOperation"].retry,
-            default_timeout=method_configs["CancelOperation"].timeout,
+            default_retry=default_retry,
+            default_timeout=default_timeout,
         )
 
         self._delete_operation = gapic_v1.method_async.wrap_method(
             self.operations_stub.DeleteOperation,
-            default_retry=method_configs["DeleteOperation"].retry,
-            default_timeout=method_configs["DeleteOperation"].timeout,
+            default_retry=default_retry,
+            default_timeout=default_timeout,
         )
 
     async def get_operation(

--- a/google/api_core/operations_v1/operations_async_client.py
+++ b/google/api_core/operations_v1/operations_async_client.py
@@ -48,14 +48,14 @@ class OperationsAsyncClient:
         self.operations_stub = operations_pb2.OperationsStub(channel)
 
         default_retry = retries.Retry(
-            initial=0.1,
-            maximum=60.0,
+            initial=0.1,  # seconds
+            maximum=60.0,  # seconds
             multiplier=1.3,
             predicate=retries.if_exception_type(
                 core_exceptions.DeadlineExceeded,
                 core_exceptions.ServiceUnavailable,
             ),
-            timeout=600.0,
+            timeout=600.0,  # seconds
         )
         default_timeout = timeouts.TimeToDeadlineTimeout(timeout=600.0)
 

--- a/google/api_core/operations_v1/operations_client.py
+++ b/google/api_core/operations_v1/operations_client.py
@@ -61,14 +61,14 @@ class OperationsClient(object):
         self.operations_stub = operations_pb2.OperationsStub(channel)
 
         default_retry = retries.Retry(
-            initial=0.1,
-            maximum=60.0,
+            initial=0.1,  # seconds
+            maximum=60.0,  # seconds
             multiplier=1.3,
             predicate=retries.if_exception_type(
                 core_exceptions.DeadlineExceeded,
                 core_exceptions.ServiceUnavailable,
             ),
-            timeout=600.0,
+            timeout=600.0,  # seconds
         )
         default_timeout = timeouts.TimeToDeadlineTimeout(timeout=600.0)
 

--- a/google/api_core/operations_v1/operations_client.py
+++ b/google/api_core/operations_v1/operations_client.py
@@ -37,9 +37,11 @@ automatically by another client class to deal with operations.
 
 import functools
 
+from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
 from google.api_core import page_iterator
-from google.api_core.operations_v1 import operations_client_config
+from google.api_core import retry as retries
+from google.api_core import timeout as timeouts
 from google.longrunning import operations_pb2
 
 
@@ -54,39 +56,44 @@ class OperationsClient(object):
             the default configuration is used.
     """
 
-    def __init__(self, channel, client_config=operations_client_config.config):
+    def __init__(self, channel, client_config=None):
         # Create the gRPC client stub.
         self.operations_stub = operations_pb2.OperationsStub(channel)
 
-        # Create all wrapped methods using the interface configuration.
-        # The interface config contains all of the default settings for retry
-        # and timeout for each RPC method.
-        interfaces = client_config["interfaces"]
-        interface_config = interfaces["google.longrunning.Operations"]
-        method_configs = gapic_v1.config.parse_method_configs(interface_config)
+        default_retry = retries.Retry(
+            initial=0.1,
+            maximum=60.0,
+            multiplier=1.3,
+            predicate=retries.if_exception_type(
+                core_exceptions.DeadlineExceeded,
+                core_exceptions.ServiceUnavailable,
+            ),
+            timeout=600.0,
+        )
+        default_timeout = timeouts.TimeToDeadlineTimeout(timeout=600.0)
 
         self._get_operation = gapic_v1.method.wrap_method(
             self.operations_stub.GetOperation,
-            default_retry=method_configs["GetOperation"].retry,
-            default_timeout=method_configs["GetOperation"].timeout,
+            default_retry=default_retry,
+            default_timeout=default_timeout,
         )
 
         self._list_operations = gapic_v1.method.wrap_method(
             self.operations_stub.ListOperations,
-            default_retry=method_configs["ListOperations"].retry,
-            default_timeout=method_configs["ListOperations"].timeout,
+            default_retry=default_retry,
+            default_timeout=default_timeout,
         )
 
         self._cancel_operation = gapic_v1.method.wrap_method(
             self.operations_stub.CancelOperation,
-            default_retry=method_configs["CancelOperation"].retry,
-            default_timeout=method_configs["CancelOperation"].timeout,
+            default_retry=default_retry,
+            default_timeout=default_timeout,
         )
 
         self._delete_operation = gapic_v1.method.wrap_method(
             self.operations_stub.DeleteOperation,
-            default_retry=method_configs["DeleteOperation"].retry,
-            default_timeout=method_configs["DeleteOperation"].timeout,
+            default_retry=default_retry,
+            default_timeout=default_timeout,
         )
 
     # Service calls

--- a/google/api_core/operations_v1/operations_client_config.py
+++ b/google/api_core/operations_v1/operations_client_config.py
@@ -14,7 +14,7 @@
 
 """gapic configuration for the googe.longrunning.operations client."""
 
-# DEPRECATED retry and timeou classes are instantiated directly
+# DEPRECATED: retry and timeout classes are instantiated directly
 config = {
     "interfaces": {
         "google.longrunning.Operations": {

--- a/google/api_core/operations_v1/operations_client_config.py
+++ b/google/api_core/operations_v1/operations_client_config.py
@@ -14,6 +14,7 @@
 
 """gapic configuration for the googe.longrunning.operations client."""
 
+# DEPRECATED retry and timeou classes are instantiated directly
 config = {
     "interfaces": {
         "google.longrunning.Operations": {

--- a/google/api_core/operations_v1/transports/rest.py
+++ b/google/api_core/operations_v1/transports/rest.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import re
 from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
 from requests import __version__ as requests_version
@@ -73,6 +74,7 @@ class OperationsRestTransport(OperationsTransport):
         always_use_jwt_access: Optional[bool] = False,
         url_scheme: str = "https",
         http_options: Optional[Dict] = None,
+        uri_prefix: str = "v1",
     ) -> None:
         """Instantiate the transport.
 
@@ -108,12 +110,24 @@ class OperationsRestTransport(OperationsTransport):
             http_options: a dictionary of http_options for transcoding, to override
                 the defaults from operatons.proto.  Each method has an entry
                 with the corresponding http rules as value.
+            uir_prefix: uri prefix (usually represents API version). Is set to
+                "v1" by default.
 
         """
         # Run the base constructor
         # TODO(yon-mg): resolve other ctor params i.e. scopes, quota, etc.
         # TODO: When custom host (api_endpoint) is set, `scopes` must *also* be set on the
         # credentials object
+        maybe_url_match = re.match("^(?P<scheme>http(?:s)?://)?(?P<host>.*)$", host)
+        if maybe_url_match is None:
+            raise ValueError(
+                f"Unexpected hostname structure: {host}"
+            )  # pragma: NO COVER
+
+        url_match_items = maybe_url_match.groupdict()
+
+        host = f"{url_scheme}://{host}" if not url_match_items["scheme"] else host
+
         super().__init__(
             host=host,
             credentials=credentials,
@@ -127,6 +141,7 @@ class OperationsRestTransport(OperationsTransport):
             self._session.configure_mtls_channel(client_cert_source_for_mtls)
         self._prep_wrapped_messages(client_info)
         self._http_options = http_options or {}
+        self._uri_prefix = uri_prefix
 
     def _list_operations(
         self,
@@ -157,7 +172,10 @@ class OperationsRestTransport(OperationsTransport):
         """
 
         http_options = [
-            {"method": "get", "uri": "/v1/{name=operations}"},
+            {
+                "method": "get",
+                "uri": "/{}/{{name=**}}/operations".format(self._uri_prefix),
+            },
         ]
         if "google.longrunning.Operations.ListOperations" in self._http_options:
             http_options = self._http_options[
@@ -188,7 +206,7 @@ class OperationsRestTransport(OperationsTransport):
         headers = dict(metadata)
         headers["Content-Type"] = "application/json"
         response = getattr(self._session, method)(
-            "https://{host}{uri}".format(host=self._host, uri=uri),
+            "{host}{uri}".format(host=self._host, uri=uri),
             timeout=timeout,
             headers=headers,
             params=rest_helpers.flatten_query_params(query_params),
@@ -234,7 +252,10 @@ class OperationsRestTransport(OperationsTransport):
         """
 
         http_options = [
-            {"method": "get", "uri": "/v1/{name=operations/**}"},
+            {
+                "method": "get",
+                "uri": "/{}/{{name=**/operations/*}}".format(self._uri_prefix),
+            },
         ]
         if "google.longrunning.Operations.GetOperation" in self._http_options:
             http_options = self._http_options[
@@ -265,7 +286,7 @@ class OperationsRestTransport(OperationsTransport):
         headers = dict(metadata)
         headers["Content-Type"] = "application/json"
         response = getattr(self._session, method)(
-            "https://{host}{uri}".format(host=self._host, uri=uri),
+            "{host}{uri}".format(host=self._host, uri=uri),
             timeout=timeout,
             headers=headers,
             params=rest_helpers.flatten_query_params(query_params),
@@ -304,7 +325,10 @@ class OperationsRestTransport(OperationsTransport):
         """
 
         http_options = [
-            {"method": "delete", "uri": "/v1/{name=operations/**}"},
+            {
+                "method": "delete",
+                "uri": "/{}/{{name=**/operations/*}}".format(self._uri_prefix),
+            },
         ]
         if "google.longrunning.Operations.DeleteOperation" in self._http_options:
             http_options = self._http_options[
@@ -335,7 +359,7 @@ class OperationsRestTransport(OperationsTransport):
         headers = dict(metadata)
         headers["Content-Type"] = "application/json"
         response = getattr(self._session, method)(
-            "https://{host}{uri}".format(host=self._host, uri=uri),
+            "{host}{uri}".format(host=self._host, uri=uri),
             timeout=timeout,
             headers=headers,
             params=rest_helpers.flatten_query_params(query_params),
@@ -371,7 +395,11 @@ class OperationsRestTransport(OperationsTransport):
         """
 
         http_options = [
-            {"method": "post", "uri": "/v1/{name=operations/**}:cancel", "body": "*"},
+            {
+                "method": "post",
+                "uri": "/{}/{{name=**/operations/*}}:cancel".format(self._uri_prefix),
+                "body": "*",
+            },
         ]
         if "google.longrunning.Operations.CancelOperation" in self._http_options:
             http_options = self._http_options[
@@ -411,7 +439,7 @@ class OperationsRestTransport(OperationsTransport):
         headers = dict(metadata)
         headers["Content-Type"] = "application/json"
         response = getattr(self._session, method)(
-            "https://{host}{uri}".format(host=self._host, uri=uri),
+            "{host}{uri}".format(host=self._host, uri=uri),
             timeout=timeout,
             headers=headers,
             params=rest_helpers.flatten_query_params(query_params),

--- a/google/api_core/operations_v1/transports/rest.py
+++ b/google/api_core/operations_v1/transports/rest.py
@@ -110,7 +110,7 @@ class OperationsRestTransport(OperationsTransport):
             http_options: a dictionary of http_options for transcoding, to override
                 the defaults from operatons.proto.  Each method has an entry
                 with the corresponding http rules as value.
-            uir_prefix: uri prefix (usually represents API version). Is set to
+            uri_prefix: uri prefix (usually represents API version). Set to
                 "v1" by default.
 
         """

--- a/google/api_core/operations_v1/transports/rest.py
+++ b/google/api_core/operations_v1/transports/rest.py
@@ -74,7 +74,7 @@ class OperationsRestTransport(OperationsTransport):
         always_use_jwt_access: Optional[bool] = False,
         url_scheme: str = "https",
         http_options: Optional[Dict] = None,
-        uri_prefix: str = "v1",
+        path_prefix: str = "v1",
     ) -> None:
         """Instantiate the transport.
 
@@ -110,7 +110,7 @@ class OperationsRestTransport(OperationsTransport):
             http_options: a dictionary of http_options for transcoding, to override
                 the defaults from operatons.proto.  Each method has an entry
                 with the corresponding http rules as value.
-            uri_prefix: uri prefix (usually represents API version). Set to
+            path_prefix: path prefix (usually represents API version). Set to
                 "v1" by default.
 
         """
@@ -141,7 +141,7 @@ class OperationsRestTransport(OperationsTransport):
             self._session.configure_mtls_channel(client_cert_source_for_mtls)
         self._prep_wrapped_messages(client_info)
         self._http_options = http_options or {}
-        self._uri_prefix = uri_prefix
+        self._path_prefix = path_prefix
 
     def _list_operations(
         self,
@@ -174,7 +174,7 @@ class OperationsRestTransport(OperationsTransport):
         http_options = [
             {
                 "method": "get",
-                "uri": "/{}/{{name=**}}/operations".format(self._uri_prefix),
+                "uri": "/{}/{{name=**}}/operations".format(self._path_prefix),
             },
         ]
         if "google.longrunning.Operations.ListOperations" in self._http_options:
@@ -254,7 +254,7 @@ class OperationsRestTransport(OperationsTransport):
         http_options = [
             {
                 "method": "get",
-                "uri": "/{}/{{name=**/operations/*}}".format(self._uri_prefix),
+                "uri": "/{}/{{name=**/operations/*}}".format(self._path_prefix),
             },
         ]
         if "google.longrunning.Operations.GetOperation" in self._http_options:
@@ -327,7 +327,7 @@ class OperationsRestTransport(OperationsTransport):
         http_options = [
             {
                 "method": "delete",
-                "uri": "/{}/{{name=**/operations/*}}".format(self._uri_prefix),
+                "uri": "/{}/{{name=**/operations/*}}".format(self._path_prefix),
             },
         ]
         if "google.longrunning.Operations.DeleteOperation" in self._http_options:
@@ -397,7 +397,7 @@ class OperationsRestTransport(OperationsTransport):
         http_options = [
             {
                 "method": "post",
-                "uri": "/{}/{{name=**/operations/*}}:cancel".format(self._uri_prefix),
+                "uri": "/{}/{{name=**/operations/*}}:cancel".format(self._path_prefix),
                 "body": "*",
             },
         ]

--- a/google/api_core/retry.py
+++ b/google/api_core/retry.py
@@ -293,7 +293,7 @@ class Retry(object):
     call (i.e. a regular one) Timeout usually stands for the RPC Timeout (if
     provided directly as a standaone value) or Retry Timeout (if provided as
     ``retry.timeout`` property of the unary RPC's retry config). For
-    ``Operation`` or ``PolllingFuture` in general Timeout stands for
+    ``Operation`` or ``PolllingFuture`` in general Timeout stands for
     Polling Timeout.
 
     Args:

--- a/google/api_core/retry.py
+++ b/google/api_core/retry.py
@@ -167,7 +167,7 @@ def retry_target(
         on_error (Callable[Exception]): A function to call while processing a
             retryable exception.  Any error raised by this function will *not*
             be caught.
-        deadline (float): DEPRECATED use ``timeout`` instead. For backward
+        deadline (float): DEPRECATED: use ``timeout`` instead. For backward
             compatibility, if specified it will override ``timeout`` parameter.
 
     Returns:
@@ -230,70 +230,69 @@ class Retry(object):
     Although the default behavior is to retry transient API errors, a
     different predicate can be provided to retry other exceptions.
 
-    There two important concepts that retry/polling behavior may operate on -
+    There two important concepts that retry/polling behavior may operate on,
     Deadline and Timeout, which need to be properly defined for the correct
     usage of this class and the rest of the library.
 
-    Deadline - a fixed point in time by which a certain operation must
-    terminate. For example if a certain operaiton has a deadline
+    Deadline: a fixed point in time by which a certain operation must
+    terminate. For example, if a certain operation has a deadline
     "2022-10-18T23:30:52.123Z" it must terminate (successfully or with an
-    error) till that time regradless of when it was started of if it has
-    ever been started at all.
+    error) by that time, regardless of when it was started or whether it
+    was started at all.
 
-    Timeout - the maximum duration of time after which a certain operation
+    Timeout: the maximum duration of time after which a certain operation
     must terminate (successfully or with an error). The countdown begins right
-    after an operation was started. For example if an operation was started at
-    09:24:00 with timeout of 75 seconds, it must terminate not later than
+    after an operation was started. For example, if an operation was started at
+    09:24:00 with timeout of 75 seconds, it must terminate no later than
     09:25:15.
 
-    Unfortunately this class (and the api-core library as a whole) has not been
-    properly distinguishing the concepts of timeout and deadline and the
-    ``deadline`` parameter actually  means ``timeout``. That is why the
-    ``deadline`` has been deprecated and ``timeout`` should be used instead. If
-    ``deadline`` parameter is set, it will override ``timeout`` parameter, thus
+    Unfortunately, in the past this class (and the api-core library as a whole) has not been
+    properly distinguishing the concepts of "timeout" and "deadline", and the
+    ``deadline`` parameter has meant ``timeout``. That is why
+    ``deadline`` has been deprecated and ``timeout`` should be used instead. If the
+    ``deadline`` parameter is set, it will override the ``timeout`` parameter. In other words,
     ``retry.deadline`` should be treated as just a deprecated alias for
     ``retry.timeout``.
 
-    In other words it is safe to assume that this class and the rest of this
-    library operates in terms of timeouts (not deadlines) unless explicitly
+    Said another way, it is safe to assume that this class and the rest of this
+    library operate in terms of timeouts (not deadlines) unless explicitly
     noted the usage of deadline semantics.
 
-    Now, when we have Timeout term properly defined, it is also important to
-    understand the three most common applications of the timeout concept in the
+    It is also important to
+    understand the three most common applications of the Timeout concept in the
     context of this library.
 
     Usually the generic Timeout term may stand for one of the following actual
-    timeouts: RPC Timeout, Retry Timeout or Polling Timeout.
+    timeouts: RPC Timeout, Retry Timeout, or Polling Timeout.
 
-    RPC Timeout - a value supplied by the client side to the server side such
+    RPC Timeout: a value supplied by the client to the server so
     that the server side knows the maximum amount of time it is expected to
-    spend handling that specifc RPC. For example, in case of a gRPC transport,
+    spend handling that specifc RPC. For example, in the case of gRPC transport,
     RPC Timeout is represented by setting "grpc-timeout" header in the HTTP2
     request. The `timeout` property of this class normally never represents the
     RPC Timeout as it is handled separately by the ``google.api_core.timeout``
     module of this library.
 
-    Retry Timeout - this is the most common meaning of the ``timeout`` property
-    of this class, and it defines how long a certain RPC may be retried in case
-    an error is returned from the server.
+    Retry Timeout: this is the most common meaning of the ``timeout`` property
+    of this class, and defines how long a certain RPC may be retried in case
+    the server returns an error.
 
-    Polling Timeout - it is similar to Retry Timeout, but defines how long the
-    client side is allowed to call polling rpc repeatedly to check a status of a
-    long running operaiton. Unlike in the retry case, the polling rpc is
-    expected to succed (its errors are supposed to be handled by the retry
-    logic). The decision if a new polling attemtp needs to be made is made
-    not based on the RPC status code but based on the status of the returned
-    status of an operation (i.e. it is higher level concept than the rpc error
-    codes).
+    Polling Timeout: defines how long the
+    client side is allowed to call the polling RPC repeatedly to check a status of a
+    long-running operation. Each polling RPC is
+    expected to succeed (its errors are supposed to be handled by the retry
+    logic). The decision as to whether a new polling attempt needs to be made is based
+    not on the RPC status code but  on the status of the returned
+    status of an operation. In other words: we will poll a long-running operation until the operation is done or the polling timeout expires. Each poll will inform us of the status of the operation. The poll consists of an RPC to the server that may itself be retried as per the poll-specific retry settings in case of errors. The operation-level retry settings do NOT apply to polling-RPC retries.
 
     With the actual timeout types being defined above, the client libraries
     often refer to just Timeout without clarifying which type specifically
     that is. In that case the actual timeout type (sometimes also refered to as
     Logical Timeout) can be determined from the context. If it is a unary rpc
     call (i.e. a regular one) Timeout usually stands for the RPC Timeout (if
-    provided directly as a standaone value) or Retry Timeout (if provided as
+    provided directly as a standalone value) or Retry Timeout (if provided as
     ``retry.timeout`` property of the unary RPC's retry config). For
-    ``Operation`` or ``PolllingFuture`` in general Timeout stands for
+    ``Operation`` or ``PollingFuture`` in general Timeout stands for
     Polling Timeout.
 
     Args:
@@ -303,9 +302,9 @@ class Retry(object):
             must be greater than 0.
         maximum (float): The maximum amount of time to delay in seconds.
         multiplier (float): The multiplier applied to the delay.
-        timeout (float): How long to keep retrying in seconds.
+        timeout (float): How long to keep retrying, in seconds.
         deadline (float): DEPRECATED: use `timeout` instead. For backward
-            compatibility, if specified it will override ``timeout`` parameter.
+            compatibility, if specified it will override the ``timeout`` parameter.
     """
 
     def __init__(
@@ -362,7 +361,7 @@ class Retry(object):
     @property
     def deadline(self):
         """
-        DEPRECATED: use ``timeout`` instead.  Check the ``Retry`` class
+        DEPRECATED: use ``timeout`` instead.  Refer to the ``Retry`` class
         documentation for details.
         """
         return self._timeout
@@ -374,7 +373,7 @@ class Retry(object):
     def with_deadline(self, deadline):
         """Return a copy of this retry with the given timeout.
 
-        DEPRECATED use :meth:`with_timeout` instead. Check the ``Retry`` class
+        DEPRECATED: use :meth:`with_timeout` instead. Refer to the ``Retry`` class
         documentation for details.
 
         Args:
@@ -389,7 +388,7 @@ class Retry(object):
         """Return a copy of this retry with the given timeout.
 
         Args:
-            timeout (float): How long to keep retrying in seconds.
+            timeout (float): How long to keep retrying, in seconds.
 
         Returns:
             Retry: A new retry instance with the given timeout.

--- a/google/api_core/retry.py
+++ b/google/api_core/retry.py
@@ -161,9 +161,7 @@ def retry_target(
             It should return True to retry or False otherwise.
         sleep_generator (Iterable[float]): An infinite iterator that determines
             how long to sleep between retries.
-        timeout (float): How long to keep retrying the target. The last sleep
-            period is shortened as necessary, so that the last retry runs at
-            ``deadline`` (and not considerably beyond it).
+        timeout (float): How long to keep retrying the target.
         on_error (Callable[Exception]): A function to call while processing a
             retryable exception.  Any error raised by this function will *not*
             be caught.

--- a/google/api_core/retry_async.py
+++ b/google/api_core/retry_async.py
@@ -68,9 +68,12 @@ _DEFAULT_INITIAL_DELAY = 1.0  # seconds
 _DEFAULT_MAXIMUM_DELAY = 60.0  # seconds
 _DEFAULT_DELAY_MULTIPLIER = 2.0
 _DEFAULT_DEADLINE = 60.0 * 2.0  # seconds
+_DEFAULT_TIMEOUT = 60.0 * 2.0  # seconds
 
 
-async def retry_target(target, predicate, sleep_generator, deadline, on_error=None):
+async def retry_target(
+    target, predicate, sleep_generator, timeout=None, on_error=None, **kwargs
+):
     """Call a function and retry if it fails.
 
     This is the lowest-level retry helper. Generally, you'll use the
@@ -84,12 +87,12 @@ async def retry_target(target, predicate, sleep_generator, deadline, on_error=No
             It should return True to retry or False otherwise.
         sleep_generator (Iterable[float]): An infinite iterator that determines
             how long to sleep between retries.
-        deadline (float): How long to keep retrying the target. The last sleep
-            period is shortened as necessary, so that the last retry runs at
-            ``deadline`` (and not considerably beyond it).
+        timeout (float): How long to keep retrying the target.
         on_error (Callable[Exception]): A function to call while processing a
             retryable exception.  Any error raised by this function will *not*
             be caught.
+        deadline (float): DEPRECATED use ``timeout`` instead. For beckward
+        compatibility, if set it will override ``timeout`` parameter.
 
     Returns:
         Any: the return value of the target function.
@@ -99,9 +102,12 @@ async def retry_target(target, predicate, sleep_generator, deadline, on_error=No
         ValueError: If the sleep generator stops yielding values.
         Exception: If the target raises a method that isn't retryable.
     """
+
+    timeout = kwargs.get("deadline", timeout)
+
     deadline_dt = (
-        (datetime_helpers.utcnow() + datetime.timedelta(seconds=deadline))
-        if deadline
+        (datetime_helpers.utcnow() + datetime.timedelta(seconds=timeout))
+        if timeout
         else None
     )
 
@@ -132,8 +138,8 @@ async def retry_target(target, predicate, sleep_generator, deadline, on_error=No
                 # Chains the raising RetryError with the root cause error,
                 # which helps observability and debugability.
                 raise exceptions.RetryError(
-                    "Deadline of {:.1f}s exceeded while calling target function".format(
-                        deadline
+                    "Timeout of {:.1f}s exceeded while calling target function".format(
+                        timeout
                     ),
                     last_exc,
                 ) from last_exc
@@ -165,12 +171,12 @@ class AsyncRetry:
             must be greater than 0.
         maximum (float): The maximum amout of time to delay in seconds.
         multiplier (float): The multiplier applied to the delay.
-        deadline (float): How long to keep retrying in seconds. The last sleep
-            period is shortened as necessary, so that the last retry runs at
-            ``deadline`` (and not considerably beyond it).
+        timeout (float): How long to keep retrying in seconds.
         on_error (Callable[Exception]): A function to call while processing
             a retryable exception. Any error raised by this function will
             *not* be caught.
+        deadline (float): DEPRECATED use ``timeout`` instead. If set it will
+        override ``timeout`` parameter.
     """
 
     def __init__(
@@ -179,14 +185,16 @@ class AsyncRetry:
         initial=_DEFAULT_INITIAL_DELAY,
         maximum=_DEFAULT_MAXIMUM_DELAY,
         multiplier=_DEFAULT_DELAY_MULTIPLIER,
-        deadline=_DEFAULT_DEADLINE,
+        timeout=_DEFAULT_TIMEOUT,
         on_error=None,
+        **kwargs
     ):
         self._predicate = predicate
         self._initial = initial
         self._multiplier = multiplier
         self._maximum = maximum
-        self._deadline = deadline
+        self._timeout = kwargs.get("deadline", timeout)
+        self._deadline = self._timeout
         self._on_error = on_error
 
     def __call__(self, func, on_error=None):
@@ -216,7 +224,7 @@ class AsyncRetry:
                 target,
                 self._predicate,
                 sleep_generator,
-                self._deadline,
+                self._timeout,
                 on_error=on_error,
             )
 
@@ -228,7 +236,7 @@ class AsyncRetry:
         initial=None,
         maximum=None,
         multiplier=None,
-        deadline=None,
+        timeout=None,
         on_error=None,
     ):
         return AsyncRetry(
@@ -236,12 +244,13 @@ class AsyncRetry:
             initial=initial or self._initial,
             maximum=maximum or self._maximum,
             multiplier=multiplier or self._multiplier,
-            deadline=deadline or self._deadline,
+            timeout=timeout or self._timeout,
             on_error=on_error or self._on_error,
         )
 
     def with_deadline(self, deadline):
         """Return a copy of this retry with the given deadline.
+        DEPRECATED use :meth:`with_timeout` instead.
 
         Args:
             deadline (float): How long to keep retrying.
@@ -249,7 +258,18 @@ class AsyncRetry:
         Returns:
             AsyncRetry: A new retry instance with the given deadline.
         """
-        return self._replace(deadline=deadline)
+        return self._replace(timeout=deadline)
+
+    def with_timeout(self, timeout):
+        """Return a copy of this retry with the given timeout.
+
+        Args:
+            timeout (float): How long to keep retrying.
+
+        Returns:
+            AsyncRetry: A new retry instance with the given timeout.
+        """
+        return self._replace(timeout=timeout)
 
     def with_predicate(self, predicate):
         """Return a copy of this retry with the given predicate.
@@ -280,12 +300,12 @@ class AsyncRetry:
     def __str__(self):
         return (
             "<AsyncRetry predicate={}, initial={:.1f}, maximum={:.1f}, "
-            "multiplier={:.1f}, deadline={:.1f}, on_error={}>".format(
+            "multiplier={:.1f}, timeout={:.1f}, on_error={}>".format(
                 self._predicate,
                 self._initial,
                 self._maximum,
                 self._multiplier,
-                self._deadline,
+                self._timeout,
                 self._on_error,
             )
         )

--- a/google/api_core/retry_async.py
+++ b/google/api_core/retry_async.py
@@ -87,12 +87,12 @@ async def retry_target(
             It should return True to retry or False otherwise.
         sleep_generator (Iterable[float]): An infinite iterator that determines
             how long to sleep between retries.
-        timeout (float): How long to keep retrying the target.
+        timeout (float): How long to keep retrying the target, in seconds.
         on_error (Callable[Exception]): A function to call while processing a
             retryable exception.  Any error raised by this function will *not*
             be caught.
-        deadline (float): DEPRECATED use ``timeout`` instead. For beckward
-        compatibility, if set it will override ``timeout`` parameter.
+        deadline (float): DEPRECATED use ``timeout`` instead. For backward
+        compatibility, if set it will override the ``timeout`` parameter.
 
     Returns:
         Any: the return value of the target function.
@@ -250,7 +250,7 @@ class AsyncRetry:
 
     def with_deadline(self, deadline):
         """Return a copy of this retry with the given deadline.
-        DEPRECATED use :meth:`with_timeout` instead.
+        DEPRECATED: use :meth:`with_timeout` instead.
 
         Args:
             deadline (float): How long to keep retrying.
@@ -264,7 +264,7 @@ class AsyncRetry:
         """Return a copy of this retry with the given timeout.
 
         Args:
-            timeout (float): How long to keep retrying.
+            timeout (float): How long to keep retrying, in seconds.
 
         Returns:
             AsyncRetry: A new retry instance with the given timeout.

--- a/google/api_core/timeout.py
+++ b/google/api_core/timeout.py
@@ -14,9 +14,9 @@
 
 """Decorators for applying timeout arguments to functions.
 
-These decorators are used to wrap API methods to apply either a constant
-(DEPRECATED), exponential (DEPRECATED) or Deadline-dependent (recommended)
-timeout argument.
+These decorators are used to wrap API methods to apply either a
+Deadline-dependent (recommended), constant (DEPRECATED) or exponential
+(DEPRECATED) timeout argument.
 
 For example, imagine an API method that can take a while to return results,
 such as one that might block until a resource is ready:

--- a/google/api_core/timeout.py
+++ b/google/api_core/timeout.py
@@ -128,7 +128,7 @@ class TimeToDeadlineTimeout(object):
 class ConstantTimeout(object):
     """A decorator that adds a constant timeout argument.
 
-    DEPRECATED: use `TimeToDeadlineTimeout` instead.
+    DEPRECATED: use ``TimeToDeadlineTimeout`` instead.
 
     This is effectively equivalent to
     ``functools.partial(func, timeout=timeout)``.
@@ -202,7 +202,7 @@ class ExponentialTimeout(object):
     """A decorator that adds an exponentially increasing timeout argument.
 
     DEPRECATED: the concept of incrementing timeout exponentially has been
-    deprecated. Use `TimeToDeadlineTimeout` instead.
+    deprecated. Use ``TimeToDeadlineTimeout`` instead.
 
     This is useful if a function is called multiple times. Each time the
     function is called this decorator will calculate a new timeout parameter

--- a/google/api_core/timeout.py
+++ b/google/api_core/timeout.py
@@ -15,7 +15,8 @@
 """Decorators for applying timeout arguments to functions.
 
 These decorators are used to wrap API methods to apply either a constant
-or exponential timeout argument.
+(DEPRECATED), exponential (DEPRECATED) or Deadline-dependent (recommended)
+timeout argument.
 
 For example, imagine an API method that can take a while to return results,
 such as one that might block until a resource is ready:
@@ -66,8 +67,68 @@ _DEFAULT_TIMEOUT_MULTIPLIER = 2.0
 _DEFAULT_DEADLINE = None
 
 
+class TimeToDeadlineTimeout(object):
+    """A decorator that decreases timeout set for an RPC based on how much time
+    has left till its deadline. The deadline is calculated as
+    ``now + initial_timeout`` when this decorator is first called for an rpc.
+
+    In other words this decorator implements deadline semantics in terms of a
+    sequence of decreasing timeouts t0 > t1 > t2 ... tn >= 0.
+
+    Args:
+        timeout (Optional[float]): the timeout (in seconds) to applied to the
+            wrapped function. If `None`, the target function is expected to
+            never timeout.
+    """
+
+    def __init__(self, timeout=None, clock=datetime_helpers.utcnow):
+        self._timeout = timeout
+        self._clock = clock
+
+    def __call__(self, func):
+        """Apply the timeout decorator.
+
+        Args:
+            func (Callable): The function to apply the timeout argument to.
+                This function must accept a timeout keyword argument.
+
+        Returns:
+            Callable: The wrapped function.
+        """
+
+        first_attempt_timestamp = self._clock().timestamp()
+
+        @functools.wraps(func)
+        def func_with_timeout(*args, **kwargs):
+            """Wrapped function that adds timeout."""
+
+            remaining_timeout = self._timeout
+            if remaining_timeout is not None:
+                # All calculations are in seconds
+                now_timestamp = self._clock().timestamp()
+
+                # To avoid usage of nonlocal but still have round timeout
+                # numbers for first attempt (in most cases the only attempt made
+                # for an RPC.
+                if now_timestamp - first_attempt_timestamp < 0.001:
+                    now_timestamp = first_attempt_timestamp
+
+                time_since_first_attempt = now_timestamp - first_attempt_timestamp
+                # Avoid setting negative timeout
+                kwargs["timeout"] = max(0, self._timeout - time_since_first_attempt)
+
+            return func(*args, **kwargs)
+
+        return func_with_timeout
+
+    def __str__(self):
+        return "<TimeToDeadlineTimeout timeout={:.1f}>".format(self._timeout)
+
+
 class ConstantTimeout(object):
     """A decorator that adds a constant timeout argument.
+
+    DEPRECATED: use `TimeToDeadlineTimeout` instead.
 
     This is effectively equivalent to
     ``functools.partial(func, timeout=timeout)``.
@@ -139,6 +200,9 @@ def _exponential_timeout_generator(initial, maximum, multiplier, deadline):
 
 class ExponentialTimeout(object):
     """A decorator that adds an exponentially increasing timeout argument.
+
+    DEPRECATED: the concept of incrementing timeout exponentially has been
+    deprecated. Use `TimeToDeadlineTimeout` instead.
 
     This is useful if a function is called multiple times. Each time the
     function is called this decorator will calculate a new timeout parameter

--- a/noxfile.py
+++ b/noxfile.py
@@ -95,7 +95,16 @@ def default(session, install_grpc=True):
     )
 
     # Install all test dependencies, then install this package in-place.
-    session.install("dataclasses", "mock", "pytest", "pytest-cov", "pytest-xdist")
+    session.install(
+        "dataclasses",
+        "mock",
+        # Revert to just "pytest" once
+        # https://github.com/pytest-dev/pytest/issues/10451 is fixed
+        "pytest<7.2.0",
+        "pytest-cov",
+        "pytest-xdist"
+    )
+
     if install_grpc:
         session.install("-e", ".[grpc]", "-c", constraints_path)
     else:

--- a/noxfile.py
+++ b/noxfile.py
@@ -204,12 +204,12 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python="3.8")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def docs(session):
     """Build the docs for this library."""
 
     session.install("-e", ".[grpc]")
-    session.install("sphinx==4.0.1", "alabaster", "recommonmark")
+    session.install("sphinx==4.2.0", "alabaster", "recommonmark")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -102,7 +102,7 @@ def default(session, install_grpc=True):
         # https://github.com/pytest-dev/pytest/issues/10451 is fixed
         "pytest<7.2.0",
         "pytest-cov",
-        "pytest-xdist"
+        "pytest-xdist",
     )
 
     if install_grpc:

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,7 +26,7 @@ BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 # Black and flake8 clash on the syntax for ignoring flake8's F401 in this file.
 BLACK_EXCLUDES = ["--exclude", "^/google/api_core/operations_v1/__init__.py"]
 
-DEFAULT_PYTHON_VERSION = "3.7"
+DEFAULT_PYTHON_VERSION = "3.10"
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 # 'docfx' is excluded since it only needs to run in 'docs-presubmit'
@@ -192,7 +192,7 @@ def mypy(session):
     session.run("mypy", "google", "tests")
 
 
-@nox.session(python="3.8")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def cover(session):
     """Run the final coverage report.
 

--- a/tests/asyncio/gapic/test_method_async.py
+++ b/tests/asyncio/gapic/test_method_async.py
@@ -198,41 +198,6 @@ async def test_wrap_method_with_overriding_retry_and_timeout(unused_sleep):
     method.assert_called_with(timeout=22, metadata=mock.ANY)
 
 
-# @mock.patch("asyncio.sleep")
-# @mock.patch(
-#     "google.api_core.datetime_helpers.utcnow",
-#     side_effect=_utcnow_monotonic(),
-#     autospec=True,
-# )
-# @pytest.mark.asyncio
-# async def test_wrap_method_with_overriding_retry_deadline(utcnow, unused_sleep):
-#     fake_call = grpc_helpers_async.FakeUnaryUnaryCall(42)
-#     method = mock.Mock(
-#         spec=aio.UnaryUnaryMultiCallable,
-#         side_effect=([exceptions.InternalServerError(None)] * 4) + [fake_call],
-#     )
-#
-#     default_retry = retry_async.AsyncRetry()
-#     default_timeout = timeout.ExponentialTimeout(deadline=60)
-#     wrapped_method = gapic_v1.method_async.wrap_method(
-#         method, default_retry, default_timeout
-#     )
-#
-#     # Overriding only the retry's deadline should also override the timeout's
-#     # deadline.
-#     result = await wrapped_method(retry=default_retry.with_deadline(30))
-#
-#     assert result == 42
-#     timeout_args = [call[1]["timeout"] for call in method.call_args_list]
-#     assert timeout_args == [5.0, 10.0, 20.0, 26.0, 25.0]
-#     assert utcnow.call_count == (
-#         1
-#         + 1  # Compute wait_for timeout in retry_async
-#         + 5  # First to set the deadline.
-#         + 5  # One for each min(timeout, maximum, (DEADLINE - NOW).seconds)
-#     )
-
-
 @pytest.mark.asyncio
 async def test_wrap_method_with_overriding_timeout_as_a_number():
     fake_call = grpc_helpers_async.FakeUnaryUnaryCall(42)

--- a/tests/asyncio/gapic/test_method_async.py
+++ b/tests/asyncio/gapic/test_method_async.py
@@ -198,39 +198,39 @@ async def test_wrap_method_with_overriding_retry_and_timeout(unused_sleep):
     method.assert_called_with(timeout=22, metadata=mock.ANY)
 
 
-@mock.patch("asyncio.sleep")
-@mock.patch(
-    "google.api_core.datetime_helpers.utcnow",
-    side_effect=_utcnow_monotonic(),
-    autospec=True,
-)
-@pytest.mark.asyncio
-async def test_wrap_method_with_overriding_retry_deadline(utcnow, unused_sleep):
-    fake_call = grpc_helpers_async.FakeUnaryUnaryCall(42)
-    method = mock.Mock(
-        spec=aio.UnaryUnaryMultiCallable,
-        side_effect=([exceptions.InternalServerError(None)] * 4) + [fake_call],
-    )
-
-    default_retry = retry_async.AsyncRetry()
-    default_timeout = timeout.ExponentialTimeout(deadline=60)
-    wrapped_method = gapic_v1.method_async.wrap_method(
-        method, default_retry, default_timeout
-    )
-
-    # Overriding only the retry's deadline should also override the timeout's
-    # deadline.
-    result = await wrapped_method(retry=default_retry.with_deadline(30))
-
-    assert result == 42
-    timeout_args = [call[1]["timeout"] for call in method.call_args_list]
-    assert timeout_args == [5.0, 10.0, 20.0, 26.0, 25.0]
-    assert utcnow.call_count == (
-        1
-        + 1  # Compute wait_for timeout in retry_async
-        + 5  # First to set the deadline.
-        + 5  # One for each min(timeout, maximum, (DEADLINE - NOW).seconds)
-    )
+# @mock.patch("asyncio.sleep")
+# @mock.patch(
+#     "google.api_core.datetime_helpers.utcnow",
+#     side_effect=_utcnow_monotonic(),
+#     autospec=True,
+# )
+# @pytest.mark.asyncio
+# async def test_wrap_method_with_overriding_retry_deadline(utcnow, unused_sleep):
+#     fake_call = grpc_helpers_async.FakeUnaryUnaryCall(42)
+#     method = mock.Mock(
+#         spec=aio.UnaryUnaryMultiCallable,
+#         side_effect=([exceptions.InternalServerError(None)] * 4) + [fake_call],
+#     )
+#
+#     default_retry = retry_async.AsyncRetry()
+#     default_timeout = timeout.ExponentialTimeout(deadline=60)
+#     wrapped_method = gapic_v1.method_async.wrap_method(
+#         method, default_retry, default_timeout
+#     )
+#
+#     # Overriding only the retry's deadline should also override the timeout's
+#     # deadline.
+#     result = await wrapped_method(retry=default_retry.with_deadline(30))
+#
+#     assert result == 42
+#     timeout_args = [call[1]["timeout"] for call in method.call_args_list]
+#     assert timeout_args == [5.0, 10.0, 20.0, 26.0, 25.0]
+#     assert utcnow.call_count == (
+#         1
+#         + 1  # Compute wait_for timeout in retry_async
+#         + 5  # First to set the deadline.
+#         + 5  # One for each min(timeout, maximum, (DEADLINE - NOW).seconds)
+#     )
 
 
 @pytest.mark.asyncio

--- a/tests/asyncio/operations_v1/test_operations_async_client.py
+++ b/tests/asyncio/operations_v1/test_operations_async_client.py
@@ -17,7 +17,7 @@ import pytest
 
 try:
     from grpc import aio
-except ImportError:
+except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 from google.api_core import grpc_helpers_async

--- a/tests/asyncio/test_grpc_helpers_async.py
+++ b/tests/asyncio/test_grpc_helpers_async.py
@@ -18,11 +18,11 @@ import pytest  # noqa: I202
 try:
     import grpc
     from grpc import aio
-except ImportError:
+except ImportError:  # pragma: NO COVER
     grpc = aio = None
 
 
-if grpc is None:
+if grpc is None:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 

--- a/tests/asyncio/test_operation_async.py
+++ b/tests/asyncio/test_operation_async.py
@@ -18,7 +18,7 @@ import pytest
 
 try:
     import grpc  # noqa: F401
-except ImportError:
+except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 from google.api_core import exceptions

--- a/tests/asyncio/test_retry_async.py
+++ b/tests/asyncio/test_retry_async.py
@@ -276,7 +276,6 @@ class TestAsyncRetry:
         target.assert_called_once_with("meep")
         sleep.assert_not_called()
 
-    # Make uniform return half of its maximum, which is the calculated sleep time.
     @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n)
     @mock.patch("asyncio.sleep", autospec=True)
     @pytest.mark.asyncio
@@ -302,7 +301,6 @@ class TestAsyncRetry:
         sleep.assert_called_once_with(retry_._initial)
         assert on_error.call_count == 1
 
-    # Make uniform return half of its maximum, which is the calculated sleep time.
     @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n)
     @mock.patch("asyncio.sleep", autospec=True)
     @pytest.mark.asyncio
@@ -376,8 +374,7 @@ class TestAsyncRetry:
         sleep.assert_not_called()
         _some_function.assert_not_called()
 
-    # Make uniform return half of its maximum, which is the calculated sleep time.
-    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n / 2.0)
+    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n)
     @mock.patch("asyncio.sleep", autospec=True)
     @pytest.mark.asyncio
     async def test___init___when_retry_is_executed(self, sleep, uniform):

--- a/tests/asyncio/test_retry_async.py
+++ b/tests/asyncio/test_retry_async.py
@@ -116,7 +116,7 @@ async def test_retry_target_deadline_exceeded(utcnow, sleep):
         await retry_async.retry_target(target, predicate, range(10), deadline=10)
 
     assert exc_info.value.cause == exception
-    assert exc_info.match("Deadline of 10.0s exceeded")
+    assert exc_info.match("Timeout of 10.0s exceeded")
     assert exc_info.match("last exception: meep")
     assert target.call_count == 2
 
@@ -253,7 +253,7 @@ class TestAsyncRetry:
         assert re.match(
             (
                 r"<AsyncRetry predicate=<function.*?if_exception_type.*?>, "
-                r"initial=1.0, maximum=60.0, multiplier=2.0, deadline=120.0, "
+                r"initial=1.0, maximum=60.0, multiplier=2.0, timeout=120.0, "
                 r"on_error=None>"
             ),
             str(retry_),
@@ -277,7 +277,7 @@ class TestAsyncRetry:
         sleep.assert_not_called()
 
     # Make uniform return half of its maximum, which is the calculated sleep time.
-    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n / 2.0)
+    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n)
     @mock.patch("asyncio.sleep", autospec=True)
     @pytest.mark.asyncio
     async def test___call___and_execute_retry(self, sleep, uniform):
@@ -303,7 +303,7 @@ class TestAsyncRetry:
         assert on_error.call_count == 1
 
     # Make uniform return half of its maximum, which is the calculated sleep time.
-    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n / 2.0)
+    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n)
     @mock.patch("asyncio.sleep", autospec=True)
     @pytest.mark.asyncio
     async def test___call___and_execute_retry_hitting_deadline(self, sleep, uniform):

--- a/tests/unit/gapic/test_method.py
+++ b/tests/unit/gapic/test_method.py
@@ -178,37 +178,6 @@ def test_wrap_method_with_overriding_retry_and_timeout(unusued_sleep):
     method.assert_called_with(timeout=22, metadata=mock.ANY)
 
 
-# @mock.patch("time.sleep")
-# @mock.patch(
-#     "google.api_core.datetime_helpers.utcnow",
-#     side_effect=_utcnow_monotonic(),
-#     autospec=True,
-# )
-# def test_wrap_method_with_overriding_retry_deadline(utcnow, unused_sleep):
-#     method = mock.Mock(
-#         spec=["__call__"],
-#         side_effect=([exceptions.InternalServerError(None)] * 4) + [42],
-#     )
-#     default_retry = retry.Retry()
-#     default_timeout = timeout.ExponentialTimeout(deadline=60)
-#     wrapped_method = google.api_core.gapic_v1.method.wrap_method(
-#         method, default_retry, default_timeout
-#     )
-#
-#     # Overriding only the retry's deadline should also override the timeout's
-#     # deadline.
-#     result = wrapped_method(retry=default_retry.with_deadline(30))
-#
-#     assert result == 42
-#     timeout_args = [call[1]["timeout"] for call in method.call_args_list]
-#     assert timeout_args == [5.0, 10.0, 20.0, 26.0, 25.0]
-#     assert utcnow.call_count == (
-#         1
-#         + 5  # First to set the deadline.
-#         + 5  # One for each min(timeout, maximum, (DEADLINE - NOW).seconds)
-#     )
-
-
 def test_wrap_method_with_overriding_timeout_as_a_number():
     method = mock.Mock(spec=["__call__"], return_value=42)
     default_retry = retry.Retry()

--- a/tests/unit/gapic/test_method.py
+++ b/tests/unit/gapic/test_method.py
@@ -39,27 +39,6 @@ def _utcnow_monotonic():
         curr_value += delta
 
 
-def test__determine_timeout():
-    # Check _determine_timeout always returns a Timeout object.
-    timeout_type_timeout = timeout.ConstantTimeout(600.0)
-    returned_timeout = google.api_core.gapic_v1.method._determine_timeout(
-        600.0, 600.0, None
-    )
-    assert isinstance(returned_timeout, timeout.ConstantTimeout)
-    returned_timeout = google.api_core.gapic_v1.method._determine_timeout(
-        600.0, timeout_type_timeout, None
-    )
-    assert isinstance(returned_timeout, timeout.ConstantTimeout)
-    returned_timeout = google.api_core.gapic_v1.method._determine_timeout(
-        timeout_type_timeout, 600.0, None
-    )
-    assert isinstance(returned_timeout, timeout.ConstantTimeout)
-    returned_timeout = google.api_core.gapic_v1.method._determine_timeout(
-        timeout_type_timeout, timeout_type_timeout, None
-    )
-    assert isinstance(returned_timeout, timeout.ConstantTimeout)
-
-
 def test_wrap_method_basic():
     method = mock.Mock(spec=["__call__"], return_value=42)
 
@@ -199,35 +178,35 @@ def test_wrap_method_with_overriding_retry_and_timeout(unusued_sleep):
     method.assert_called_with(timeout=22, metadata=mock.ANY)
 
 
-@mock.patch("time.sleep")
-@mock.patch(
-    "google.api_core.datetime_helpers.utcnow",
-    side_effect=_utcnow_monotonic(),
-    autospec=True,
-)
-def test_wrap_method_with_overriding_retry_deadline(utcnow, unused_sleep):
-    method = mock.Mock(
-        spec=["__call__"],
-        side_effect=([exceptions.InternalServerError(None)] * 4) + [42],
-    )
-    default_retry = retry.Retry()
-    default_timeout = timeout.ExponentialTimeout(deadline=60)
-    wrapped_method = google.api_core.gapic_v1.method.wrap_method(
-        method, default_retry, default_timeout
-    )
-
-    # Overriding only the retry's deadline should also override the timeout's
-    # deadline.
-    result = wrapped_method(retry=default_retry.with_deadline(30))
-
-    assert result == 42
-    timeout_args = [call[1]["timeout"] for call in method.call_args_list]
-    assert timeout_args == [5.0, 10.0, 20.0, 26.0, 25.0]
-    assert utcnow.call_count == (
-        1
-        + 5  # First to set the deadline.
-        + 5  # One for each min(timeout, maximum, (DEADLINE - NOW).seconds)
-    )
+# @mock.patch("time.sleep")
+# @mock.patch(
+#     "google.api_core.datetime_helpers.utcnow",
+#     side_effect=_utcnow_monotonic(),
+#     autospec=True,
+# )
+# def test_wrap_method_with_overriding_retry_deadline(utcnow, unused_sleep):
+#     method = mock.Mock(
+#         spec=["__call__"],
+#         side_effect=([exceptions.InternalServerError(None)] * 4) + [42],
+#     )
+#     default_retry = retry.Retry()
+#     default_timeout = timeout.ExponentialTimeout(deadline=60)
+#     wrapped_method = google.api_core.gapic_v1.method.wrap_method(
+#         method, default_retry, default_timeout
+#     )
+#
+#     # Overriding only the retry's deadline should also override the timeout's
+#     # deadline.
+#     result = wrapped_method(retry=default_retry.with_deadline(30))
+#
+#     assert result == 42
+#     timeout_args = [call[1]["timeout"] for call in method.call_args_list]
+#     assert timeout_args == [5.0, 10.0, 20.0, 26.0, 25.0]
+#     assert utcnow.call_count == (
+#         1
+#         + 5  # First to set the deadline.
+#         + 5  # One for each min(timeout, maximum, (DEADLINE - NOW).seconds)
+#     )
 
 
 def test_wrap_method_with_overriding_timeout_as_a_number():

--- a/tests/unit/operations_v1/test_operations_client.py
+++ b/tests/unit/operations_v1/test_operations_client.py
@@ -16,12 +16,13 @@ import pytest
 
 try:
     import grpc  # noqa: F401
-except ImportError:
+except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 from google.api_core import grpc_helpers
 from google.api_core import operations_v1
 from google.api_core import page_iterator
+from google.api_core.operations_v1 import operations_client_config
 from google.longrunning import operations_pb2
 from google.protobuf import empty_pb2
 
@@ -96,3 +97,7 @@ def test_cancel_operation():
     ].metadata
     assert len(channel.CancelOperation.requests) == 1
     assert channel.CancelOperation.requests[0].name == "name"
+
+
+def test_operations_client_config():
+    assert operations_client_config.config["interfaces"]

--- a/tests/unit/operations_v1/test_operations_rest_client.py
+++ b/tests/unit/operations_v1/test_operations_rest_client.py
@@ -20,7 +20,7 @@ import pytest
 
 try:
     import grpc  # noqa: F401
-except ImportError:
+except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 from requests import Response  # noqa I201
 from requests.sessions import Session
@@ -121,7 +121,7 @@ def test_operations_client_from_service_account_info(client_class):
         assert client.transport._credentials == creds
         assert isinstance(client, client_class)
 
-        assert client.transport._host == "longrunning.googleapis.com:443"
+        assert client.transport._host == "https://longrunning.googleapis.com"
 
 
 @pytest.mark.parametrize(
@@ -160,7 +160,7 @@ def test_operations_client_from_service_account_file(client_class):
         assert client.transport._credentials == creds
         assert isinstance(client, client_class)
 
-        assert client.transport._host == "longrunning.googleapis.com:443"
+        assert client.transport._host == "https://longrunning.googleapis.com"
 
 
 def test_operations_client_get_transport_class():
@@ -465,10 +465,7 @@ def test_list_operations_rest(
 
         actual_args = req.call_args
         assert actual_args.args[0] == "GET"
-        assert (
-            actual_args.args[1]
-            == "https://longrunning.googleapis.com:443/v3/operations"
-        )
+        assert actual_args.args[1] == "https://longrunning.googleapis.com/v3/operations"
         assert actual_args.kwargs["params"] == [
             ("filter", "my_filter"),
             ("pageSize", 10),
@@ -574,7 +571,7 @@ def test_get_operation_rest(
     assert actual_args.args[0] == "GET"
     assert (
         actual_args.args[1]
-        == "https://longrunning.googleapis.com:443/v3/operations/sample1"
+        == "https://longrunning.googleapis.com/v3/operations/sample1"
     )
 
     # Establish that the response is the type that we expect.
@@ -591,13 +588,11 @@ def test_get_operation_rest_failure():
         response_value.status_code = 400
         mock_request = mock.MagicMock()
         mock_request.method = "GET"
-        mock_request.url = (
-            "https://longrunning.googleapis.com:443/v1/operations/sample1"
-        )
+        mock_request.url = "https://longrunning.googleapis.com/v1/operations/sample1"
         response_value.request = mock_request
         req.return_value = response_value
         with pytest.raises(core_exceptions.GoogleAPIError):
-            client.get_operation("operations/sample1")
+            client.get_operation("sammple0/operations/sample1")
 
 
 def test_delete_operation_rest(
@@ -619,7 +614,7 @@ def test_delete_operation_rest(
         assert actual_args.args[0] == "DELETE"
         assert (
             actual_args.args[1]
-            == "https://longrunning.googleapis.com:443/v3/operations/sample1"
+            == "https://longrunning.googleapis.com/v3/operations/sample1"
         )
 
 
@@ -631,13 +626,11 @@ def test_delete_operation_rest_failure():
         response_value.status_code = 400
         mock_request = mock.MagicMock()
         mock_request.method = "DELETE"
-        mock_request.url = (
-            "https://longrunning.googleapis.com:443/v1/operations/sample1"
-        )
+        mock_request.url = "https://longrunning.googleapis.com/v1/operations/sample1"
         response_value.request = mock_request
         req.return_value = response_value
         with pytest.raises(core_exceptions.GoogleAPIError):
-            client.delete_operation(name="operations/sample1")
+            client.delete_operation(name="sample0/operations/sample1")
 
 
 def test_cancel_operation_rest(transport: str = "rest"):
@@ -657,7 +650,7 @@ def test_cancel_operation_rest(transport: str = "rest"):
         assert actual_args.args[0] == "POST"
         assert (
             actual_args.args[1]
-            == "https://longrunning.googleapis.com:443/v3/operations/sample1:cancel"
+            == "https://longrunning.googleapis.com/v3/operations/sample1:cancel"
         )
 
 
@@ -670,12 +663,12 @@ def test_cancel_operation_rest_failure():
         mock_request = mock.MagicMock()
         mock_request.method = "POST"
         mock_request.url = (
-            "https://longrunning.googleapis.com:443/v1/operations/sample1:cancel"
+            "https://longrunning.googleapis.com/v1/operations/sample1:cancel"
         )
         response_value.request = mock_request
         req.return_value = response_value
         with pytest.raises(core_exceptions.GoogleAPIError):
-            client.cancel_operation(name="operations/sample1")
+            client.cancel_operation(name="sample0/operations/sample1")
 
 
 def test_credentials_transport_error():
@@ -825,7 +818,7 @@ def test_operations_host_no_port():
             api_endpoint="longrunning.googleapis.com"
         ),
     )
-    assert client.transport._host == "longrunning.googleapis.com:443"
+    assert client.transport._host == "https://longrunning.googleapis.com"
 
 
 def test_operations_host_with_port():
@@ -835,7 +828,7 @@ def test_operations_host_with_port():
             api_endpoint="longrunning.googleapis.com:8000"
         ),
     )
-    assert client.transport._host == "longrunning.googleapis.com:8000"
+    assert client.transport._host == "https://longrunning.googleapis.com:8000"
 
 
 def test_common_billing_account_path():

--- a/tests/unit/test_bidi.py
+++ b/tests/unit/test_bidi.py
@@ -22,7 +22,7 @@ import pytest
 
 try:
     import grpc
-except ImportError:
+except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 from google.api_core import bidi

--- a/tests/unit/test_client_info.py
+++ b/tests/unit/test_client_info.py
@@ -15,7 +15,7 @@
 
 try:
     import grpc
-except ImportError:
+except ImportError:  # pragma: NO COVER
     grpc = None
 
 from google.api_core import client_info
@@ -26,9 +26,9 @@ def test_constructor_defaults():
 
     assert info.python_version is not None
 
-    if grpc is not None:
+    if grpc is not None:  # pragma: NO COVER
         assert info.grpc_version is not None
-    else:
+    else:  # pragma: NO COVER
         assert info.grpc_version is None
 
     assert info.api_core_version is not None

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -22,7 +22,7 @@ import requests
 try:
     import grpc
     from grpc_status import rpc_status
-except ImportError:
+except ImportError:  # pragma: NO COVER
     grpc = rpc_status = None
 
 from google.api_core import exceptions

--- a/tests/unit/test_general_helpers.py
+++ b/tests/unit/test_general_helpers.py
@@ -1,0 +1,13 @@
+# Copyright 2022, Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit/test_grpc_helpers.py
+++ b/tests/unit/test_grpc_helpers.py
@@ -17,7 +17,7 @@ import pytest
 
 try:
     import grpc
-except ImportError:
+except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 from google.api_core import exceptions
@@ -365,7 +365,7 @@ def test_create_channel_implicit(grpc_secure_channel, default, composite_creds_c
 
     default.assert_called_once_with(scopes=None, default_scopes=None)
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -400,7 +400,7 @@ def test_create_channel_implicit_with_default_host(
         mock.sentinel.credentials, mock.sentinel.Request, default_host=default_host
     )
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -427,7 +427,7 @@ def test_create_channel_implicit_with_ssl_creds(
     composite_creds_call.assert_called_once_with(ssl_creds, mock.ANY)
     composite_creds = composite_creds_call.return_value
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -452,7 +452,7 @@ def test_create_channel_implicit_with_scopes(
 
     default.assert_called_once_with(scopes=["one", "two"], default_scopes=None)
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -477,7 +477,7 @@ def test_create_channel_implicit_with_default_scopes(
 
     default.assert_called_once_with(scopes=None, default_scopes=["three", "four"])
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -509,7 +509,7 @@ def test_create_channel_explicit(grpc_secure_channel, auth_creds, composite_cred
 
     assert channel is grpc_secure_channel.return_value
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -533,7 +533,7 @@ def test_create_channel_explicit_scoped(grpc_secure_channel, composite_creds_cal
 
     assert channel is grpc_secure_channel.return_value
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -561,7 +561,7 @@ def test_create_channel_explicit_default_scopes(
 
     assert channel is grpc_secure_channel.return_value
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -587,7 +587,7 @@ def test_create_channel_explicit_with_quota_project(
 
     assert channel is grpc_secure_channel.return_value
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -616,7 +616,7 @@ def test_create_channel_with_credentials_file(
 
     assert channel is grpc_secure_channel.return_value
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -648,7 +648,7 @@ def test_create_channel_with_credentials_file_and_scopes(
 
     assert channel is grpc_secure_channel.return_value
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -680,7 +680,7 @@ def test_create_channel_with_credentials_file_and_default_scopes(
 
     assert channel is grpc_secure_channel.return_value
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -690,7 +690,7 @@ def test_create_channel_with_credentials_file_and_default_scopes(
     not grpc_helpers.HAS_GRPC_GCP, reason="grpc_gcp module not available"
 )
 @mock.patch("grpc_gcp.secure_channel")
-def test_create_channel_with_grpc_gcp(grpc_gcp_secure_channel):
+def test_create_channel_with_grpc_gcp(grpc_gcp_secure_channel):  # pragma: NO COVER
     target = "example.com:443"
     scopes = ["test_scope"]
 

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -18,7 +18,7 @@ import pytest
 
 try:
     import grpc  # noqa: F401
-except ImportError:
+except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 from google.api_core import exceptions

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -338,7 +338,6 @@ class TestRetry(object):
         target.assert_called_once_with("meep")
         sleep.assert_not_called()
 
-    # Make uniform return half of its maximum, which is the calculated sleep time.
     @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n)
     @mock.patch("time.sleep", autospec=True)
     def test___call___and_execute_retry(self, sleep, uniform):
@@ -361,7 +360,6 @@ class TestRetry(object):
         sleep.assert_called_once_with(retry_._initial)
         assert on_error.call_count == 1
 
-    # Make uniform return half of its maximum, which is the calculated sleep time.
     @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n)
     @mock.patch("time.sleep", autospec=True)
     def test___call___and_execute_retry_hitting_deadline(self, sleep, uniform):
@@ -442,8 +440,7 @@ class TestRetry(object):
         sleep.assert_not_called()
         _some_function.assert_not_called()
 
-    # Make uniform return half of its maximum, which is the calculated sleep time.
-    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n / 2.0)
+    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n)
     @mock.patch("time.sleep", autospec=True)
     def test___init___when_retry_is_executed(self, sleep, uniform):
         _some_function = mock.Mock()

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -52,7 +52,7 @@ def test_if_transient_error():
 
 # Make uniform return half of its maximum, which will be the calculated
 # sleep time.
-@mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n / 2.0)
+@mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n)
 def test_exponential_sleep_generator_base_2(uniform):
     gen = retry.exponential_sleep_generator(1, 60, multiplier=2)
 
@@ -172,6 +172,7 @@ class TestRetry(object):
         assert retry_._deadline == 120
         assert retry_._on_error is None
         assert retry_.deadline == 120
+        assert retry_.timeout == 120
 
     def test_constructor_options(self):
         _some_function = mock.Mock()
@@ -315,7 +316,7 @@ class TestRetry(object):
         assert re.match(
             (
                 r"<Retry predicate=<function.*?if_exception_type.*?>, "
-                r"initial=1.0, maximum=60.0, multiplier=2.0, deadline=120.0, "
+                r"initial=1.0, maximum=60.0, multiplier=2.0, timeout=120.0, "
                 r"on_error=None>"
             ),
             str(retry_),
@@ -338,7 +339,7 @@ class TestRetry(object):
         sleep.assert_not_called()
 
     # Make uniform return half of its maximum, which is the calculated sleep time.
-    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n / 2.0)
+    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n)
     @mock.patch("time.sleep", autospec=True)
     def test___call___and_execute_retry(self, sleep, uniform):
 
@@ -361,7 +362,7 @@ class TestRetry(object):
         assert on_error.call_count == 1
 
     # Make uniform return half of its maximum, which is the calculated sleep time.
-    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n / 2.0)
+    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n)
     @mock.patch("time.sleep", autospec=True)
     def test___call___and_execute_retry_hitting_deadline(self, sleep, uniform):
 
@@ -371,7 +372,7 @@ class TestRetry(object):
             initial=1.0,
             maximum=1024.0,
             multiplier=2.0,
-            deadline=9.9,
+            deadline=30.9,
         )
 
         utcnow = datetime.datetime.utcnow()
@@ -406,8 +407,17 @@ class TestRetry(object):
         last_wait = sleep.call_args.args[0]
         total_wait = sum(call_args.args[0] for call_args in sleep.call_args_list)
 
-        assert last_wait == 2.9  # and not 8.0, because the last delay was shortened
-        assert total_wait == 9.9  # the same as the deadline
+        assert last_wait == 8.0
+        # Next attempt would be scheduled in 16 secs, 15 + 16 = 31 > 30.9, thus
+        # we do not even wait for it to be scheduled (30.9 is configured timeout).
+        # This changes the previous logic of shortening the last attempt to fit
+        # in the deadline. The previous logic was removed to make Python retry
+        # logic consistent with the other languages and to not disrupt the
+        # randomized retry delays distribution by artificially increasing a
+        # probability of scheduling two (instead of one) last attempts with very
+        # short delay between them, while the second retry having very low chance
+        # of succeeding anyways.
+        assert total_wait == 15.0
 
     @mock.patch("time.sleep", autospec=True)
     def test___init___without_retry_executed(self, sleep):

--- a/tests/unit/test_timeout.py
+++ b/tests/unit/test_timeout.py
@@ -17,11 +17,11 @@ import itertools
 
 import mock
 
-from google.api_core import timeout
+from google.api_core import timeout as timeouts
 
 
 def test__exponential_timeout_generator_base_2():
-    gen = timeout._exponential_timeout_generator(1.0, 60.0, 2.0, deadline=None)
+    gen = timeouts._exponential_timeout_generator(1.0, 60.0, 2.0, deadline=None)
 
     result = list(itertools.islice(gen, 8))
     assert result == [1, 2, 4, 8, 16, 32, 60, 60]
@@ -34,7 +34,7 @@ def test__exponential_timeout_generator_base_deadline(utcnow):
         datetime.datetime.min + datetime.timedelta(seconds=n) for n in range(15)
     ]
 
-    gen = timeout._exponential_timeout_generator(1.0, 60.0, 2.0, deadline=30.0)
+    gen = timeouts._exponential_timeout_generator(1.0, 60.0, 2.0, deadline=30.0)
 
     result = list(itertools.islice(gen, 14))
     # Should grow until the cumulative time is > 30s, then start decreasing as
@@ -42,22 +42,105 @@ def test__exponential_timeout_generator_base_deadline(utcnow):
     assert result == [1, 2, 4, 8, 16, 24, 23, 22, 21, 20, 19, 18, 17, 16]
 
 
-class TestConstantTimeout(object):
+class TestTimeToDeadlineTimeout(object):
     def test_constructor(self):
-        timeout_ = timeout.ConstantTimeout()
+        timeout_ = timeouts.TimeToDeadlineTimeout()
         assert timeout_._timeout is None
 
     def test_constructor_args(self):
-        timeout_ = timeout.ConstantTimeout(42.0)
+        timeout_ = timeouts.TimeToDeadlineTimeout(42.0)
         assert timeout_._timeout == 42.0
 
     def test___str__(self):
-        timeout_ = timeout.ConstantTimeout(1)
+        timeout_ = timeouts.TimeToDeadlineTimeout(1)
+        assert str(timeout_) == "<TimeToDeadlineTimeout timeout=1.0>"
+
+    def test_apply(self):
+        target = mock.Mock(spec=["__call__", "__name__"], __name__="target")
+
+        datetime.datetime.utcnow()
+        datetime.timedelta(seconds=1)
+
+        now = datetime.datetime.utcnow()
+
+        times = [
+            now,
+            now + datetime.timedelta(seconds=0.0009),
+            now + datetime.timedelta(seconds=1),
+            now + datetime.timedelta(seconds=39),
+            now + datetime.timedelta(seconds=42),
+            now + datetime.timedelta(seconds=43),
+        ]
+
+        def _clock():
+            return times.pop(0)
+
+        timeout_ = timeouts.TimeToDeadlineTimeout(42.0, _clock)
+        wrapped = timeout_(target)
+
+        wrapped()
+        target.assert_called_with(timeout=42.0)
+        wrapped()
+        target.assert_called_with(timeout=41.0)
+        wrapped()
+        target.assert_called_with(timeout=3.0)
+        wrapped()
+        target.assert_called_with(timeout=0.0)
+        wrapped()
+        target.assert_called_with(timeout=0.0)
+
+    def test_apply_no_timeout(self):
+        target = mock.Mock(spec=["__call__", "__name__"], __name__="target")
+
+        datetime.datetime.utcnow()
+        datetime.timedelta(seconds=1)
+
+        now = datetime.datetime.utcnow()
+
+        times = [
+            now,
+            now + datetime.timedelta(seconds=0.0009),
+            now + datetime.timedelta(seconds=1),
+            now + datetime.timedelta(seconds=2),
+        ]
+
+        def _clock():
+            return times.pop(0)
+
+        timeout_ = timeouts.TimeToDeadlineTimeout(clock=_clock)
+        wrapped = timeout_(target)
+
+        wrapped()
+        target.assert_called_with()
+        wrapped()
+        target.assert_called_with()
+
+    def test_apply_passthrough(self):
+        target = mock.Mock(spec=["__call__", "__name__"], __name__="target")
+        timeout_ = timeouts.TimeToDeadlineTimeout(42.0)
+        wrapped = timeout_(target)
+
+        wrapped(1, 2, meep="moop")
+
+        target.assert_called_once_with(1, 2, meep="moop", timeout=42.0)
+
+
+class TestConstantTimeout(object):
+    def test_constructor(self):
+        timeout_ = timeouts.ConstantTimeout()
+        assert timeout_._timeout is None
+
+    def test_constructor_args(self):
+        timeout_ = timeouts.ConstantTimeout(42.0)
+        assert timeout_._timeout == 42.0
+
+    def test___str__(self):
+        timeout_ = timeouts.ConstantTimeout(1)
         assert str(timeout_) == "<ConstantTimeout timeout=1.0>"
 
     def test_apply(self):
         target = mock.Mock(spec=["__call__", "__name__"], __name__="target")
-        timeout_ = timeout.ConstantTimeout(42.0)
+        timeout_ = timeouts.ConstantTimeout(42.0)
         wrapped = timeout_(target)
 
         wrapped()
@@ -66,7 +149,7 @@ class TestConstantTimeout(object):
 
     def test_apply_passthrough(self):
         target = mock.Mock(spec=["__call__", "__name__"], __name__="target")
-        timeout_ = timeout.ConstantTimeout(42.0)
+        timeout_ = timeouts.ConstantTimeout(42.0)
         wrapped = timeout_(target)
 
         wrapped(1, 2, meep="moop")
@@ -76,30 +159,30 @@ class TestConstantTimeout(object):
 
 class TestExponentialTimeout(object):
     def test_constructor(self):
-        timeout_ = timeout.ExponentialTimeout()
-        assert timeout_._initial == timeout._DEFAULT_INITIAL_TIMEOUT
-        assert timeout_._maximum == timeout._DEFAULT_MAXIMUM_TIMEOUT
-        assert timeout_._multiplier == timeout._DEFAULT_TIMEOUT_MULTIPLIER
-        assert timeout_._deadline == timeout._DEFAULT_DEADLINE
+        timeout_ = timeouts.ExponentialTimeout()
+        assert timeout_._initial == timeouts._DEFAULT_INITIAL_TIMEOUT
+        assert timeout_._maximum == timeouts._DEFAULT_MAXIMUM_TIMEOUT
+        assert timeout_._multiplier == timeouts._DEFAULT_TIMEOUT_MULTIPLIER
+        assert timeout_._deadline == timeouts._DEFAULT_DEADLINE
 
     def test_constructor_args(self):
-        timeout_ = timeout.ExponentialTimeout(1, 2, 3, 4)
+        timeout_ = timeouts.ExponentialTimeout(1, 2, 3, 4)
         assert timeout_._initial == 1
         assert timeout_._maximum == 2
         assert timeout_._multiplier == 3
         assert timeout_._deadline == 4
 
     def test_with_timeout(self):
-        original_timeout = timeout.ExponentialTimeout()
+        original_timeout = timeouts.ExponentialTimeout()
         timeout_ = original_timeout.with_deadline(42)
         assert original_timeout is not timeout_
-        assert timeout_._initial == timeout._DEFAULT_INITIAL_TIMEOUT
-        assert timeout_._maximum == timeout._DEFAULT_MAXIMUM_TIMEOUT
-        assert timeout_._multiplier == timeout._DEFAULT_TIMEOUT_MULTIPLIER
+        assert timeout_._initial == timeouts._DEFAULT_INITIAL_TIMEOUT
+        assert timeout_._maximum == timeouts._DEFAULT_MAXIMUM_TIMEOUT
+        assert timeout_._multiplier == timeouts._DEFAULT_TIMEOUT_MULTIPLIER
         assert timeout_._deadline == 42
 
     def test___str__(self):
-        timeout_ = timeout.ExponentialTimeout(1, 2, 3, 4)
+        timeout_ = timeouts.ExponentialTimeout(1, 2, 3, 4)
         assert str(timeout_) == (
             "<ExponentialTimeout initial=1.0, maximum=2.0, multiplier=3.0, "
             "deadline=4.0>"
@@ -107,7 +190,7 @@ class TestExponentialTimeout(object):
 
     def test_apply(self):
         target = mock.Mock(spec=["__call__", "__name__"], __name__="target")
-        timeout_ = timeout.ExponentialTimeout(1, 10, 2)
+        timeout_ = timeouts.ExponentialTimeout(1, 10, 2)
         wrapped = timeout_(target)
 
         wrapped()
@@ -121,7 +204,7 @@ class TestExponentialTimeout(object):
 
     def test_apply_passthrough(self):
         target = mock.Mock(spec=["__call__", "__name__"], __name__="target")
-        timeout_ = timeout.ExponentialTimeout(42.0, 100, 2)
+        timeout_ = timeouts.ExponentialTimeout(42.0, 100, 2)
         wrapped = timeout_(target)
 
         wrapped(1, 2, meep="moop")


### PR DESCRIPTION
If you are a  user of python-api-core and experience polling timing out after ~15 minutes (900s) in your python code after this change, please make sure that instead of calling `PollingFuture.result()` you call it with additonal `timeout` argument like this: `PollingFuture.result(timeout = <desired timeout in seconds>)` or `PollingFuture.result(timeout = None)` (for infinite timeout, but infinite timeouts are strongly **discouraged**) for  your code to stop timing out at 900s.

The core libraries cannot and should not have infitine polling as as default behavior. The fact that it had it like that in python for years (unlike other GCP-supported languages) was a bug, as it contradicts original cross-language LRO methods design in GAPIC libraries and in general users are not supposed to be put into an infinite-loop scenario implicitly. If an LRO can actually ran for hours or even days and it is Ok, then users are expected to acknowledge this fact by providing the huge timeouts explicitly.

This is in response to https://freeman.vc/notes/aws-vs-gcp-reliability-is-wildly-different, which triggered an investigation of the whole Polling/Retry/Timeout behavior in Python GAPIC clients and revealed many fundamental flaws in its implementation.

To properly describe the refactoring in this PR we need to stick to a rigorous terminology, as vague definitions of retries, timeouts, polling and related concepts seems to be the main source of the present bugs and overall confusion among both groups: users of the library and creators of the library. Please check the updated (in this PR) documentation of the `google.api_core.retry.Retry` class and the `google.api_core.future.polling.Polling.result()` method for the proper definitions and context.

Note, the overall semantics around Polling, Retry and Timeout remains quite confusing even after refactoring (although it is now more or less rigorously defined), but it was as clean as I could make it while still maintaining backward compatibility of the whole library.

The quick summary of the changes in this PR:

1) Properly define and fix the application of Deadline and Timeout concepts. Please check the updated documentation for the `google.api_core.retry.Retry` class for the actual definitions. Originally the `deadline` has been used to represent timeouts conflating the two concepts. As result this PR replaces `deadline` arguments with `timeout` ones in as backward-compatible manner as possible (i.e. backward compatible in all practical applications).

2) Properly define RPC Timeout, Retry Timeout and Polling Timeout and how a generic Timeout concept (aka Logical Timeout) is mapped to one of those depending on the context. Please check `google.api_core.retry.Retry` class documentation for details.

3) Properly define and fix the application of Retry and Polling concepts. Please check the updated documentation for `google.api_core.future.polling.PollingFuture.result()` for details.

4) Separate `retry` and `polling` configurations for Polling future, as these are two different concepts (although both operating on `Retry` class). Originally both retry and polling configurations were controlled by a single `retry` parameter, merging configuration regarding how "rpc error responses" and how "operation not completed" responses are supposed to be handled.

5) For the following config properties - `Retry` (including `Retry Timeout`), `Polling` (including `Polling Timeout`) and `RPC Timeout` - fix and properly define how each of the above properties gets configured and which config gets precedence in case of a conflict (check `PollingFuture.result()` method documentation for details). Each of those properties can be specified as follows: directly provided by the user for each call, specified during gapic generation time from config values in `grpc_service_config.json` file (for Retry and RPC Timeout) and `gapic.yaml` file (for Polling Timeout), or be provided as a hard-coded basic default values in python-api-core library itself. This alo includes fixing the per-call polling config propagation logic (the polling/retry configs supplied to `PollingFuture.result()` used to be ignored for actual call).

6) Deprecate `ExponentialTimeout`, `ConstantTimeout` and related logic as those are outdated concepts and are not consistent with the other GAPIC Languages. Replace it with `TimeToDeadlineTimeout` to be consistent with how the rest of the languages do it.

7) Deprecate `google.api_core.operations_v1.config` as it is an outdated concept and self-inconsistent (as all gapic clients provide configuraiton in code). The configs are directly provided in code instead.

8) Switch randomized delay calculation from `delay` being treated as expected value for randomized_delay to `delay` being treated as maximum value for `randomized_delay` (i.e. the new expected valud for `randomized_delay` is `delay / 2`). See the `exponential_sleep_generator()` method implementation for details. This is needed to make Python implementation of retries and polling exponential backoff consistent with the rest of GAPIC languages. Also fix the uncontrollable growth of `delay` value (since it is a subject of exponential growth, the `delay` value was quickly reaching "infinity" value, and the whole thing was not failing simply due to python being a very forgiving language which forgives multiplying "infinity" by a number (`inf * number = inf`) binstead of simply overflowing to a (most likely) negative number). Also essentially rollback  the https://github.com/googleapis/python-api-core/commit/52f12af027568ddeae7fb6b1e3d2111cce1bac08 change, since that is inconsistent with the other languages and damages uniform distibution of retry delays artificially shifting  their concentration towards the end of timeout.

9) Fix url construction in `OperationsRestTransport`. Without this fix the polling logic for REST transport was completely broken (is not affecting Compute client, as that one has custom LRO).

10) Last but not least: change the default values for Polling logic to be the following: `initial=1.0` (same as before), `maximum=20.0` (was `60`), `multiplier=1.5` (was `2.0`), `timeout=900` (was `120`, but due to timeout resolution logic was actually None (i.e. infinity)). This, in conjunction with changed calculation of randomized delay (i.e. its expected value now being  `delay / 2`) overall makes polling logic much less aggressive in terms of increasing delays between each polling iteration, making LRO return much earlier for users on average, but still keeping a healthy balance between strain put on both client and server by polling and responsiveness of LROs for user.

*The design doc summarising all the changes and reasons for them is in progress.

In addition to the timeout/retry fixes, this PR has some other non-related technical fixes: 
- Fix and improve code coverage (and explicitly disables lines which are not supposed to be covered) 
- Define `Python 3.10` as the default python version used in CI.
- Upgrade to Sphinx 4.2.0, as it is the one supporting Python 3.10
