### PR TITLE
fix: require google-auth >= 2.14.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "googleapis-common-protos >= 1.56.2, < 2.0dev",
     "protobuf>=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
-    "google-auth >= 1.25.0, < 3.0dev",
+    "google-auth >= 2.13.0, < 3.0dev",
     "requests >= 2.18.0, < 3.0.0dev",
 ]
 extras = {

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "googleapis-common-protos >= 1.56.2, < 2.0dev",
     "protobuf>=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
-    "google-auth >= 2.13.0, < 3.0dev",
+    "google-auth >= 2.14.1, < 3.0dev",
     "requests >= 2.18.0, < 3.0.0dev",
 ]
 extras = {

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -7,7 +7,7 @@
 # Then this file should have foo==1.14.0
 googleapis-common-protos==1.56.2
 protobuf==3.19.5
-google-auth==1.25.0
+google-auth==2.13.0
 requests==2.18.0
 packaging==14.3
 grpcio==1.33.2

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -7,7 +7,7 @@
 # Then this file should have foo==1.14.0
 googleapis-common-protos==1.56.2
 protobuf==3.19.5
-google-auth==2.13.0
+google-auth==2.14.1
 requests==2.18.0
 packaging==14.3
 grpcio==1.33.2


### PR DESCRIPTION
Set the minimum google-auth version to 2.14.1 which requires version `38.0.3` of cryptography 

https://github.com/googleapis/google-auth-library-python/releases/tag/v2.14.1