### PR TITLE
fix: Major refactoring of Polling, Retry and Timeout logic in v1 branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.9"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel
@@ -28,7 +28,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.9"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.7"
+        python-version: "3.10"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.7"
+        python-version: "3.10"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/.kokoro/docker/docs/Dockerfile
+++ b/.kokoro/docker/docs/Dockerfile
@@ -60,16 +60,16 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/* \
   && rm -f /var/cache/apt/archives/*.deb
 
-###################### Install python 3.8.11
+###################### Install python 3.9.13
 
-# Download python 3.8.11
-RUN wget https://www.python.org/ftp/python/3.8.11/Python-3.8.11.tgz
+# Download python 3.9.13
+RUN wget https://www.python.org/ftp/python/3.9.13/Python-3.9.13.tgz
 
 # Extract files
-RUN tar -xvf Python-3.8.11.tgz
+RUN tar -xvf Python-3.9.13.tgz
 
-# Install python 3.8.11
-RUN ./Python-3.8.11/configure --enable-optimizations
+# Install python 3.9.13
+RUN ./Python-3.9.13/configure --enable-optimizations
 RUN make altinstall
 
 ###################### Install pip

--- a/.kokoro/requirements.in
+++ b/.kokoro/requirements.in
@@ -6,3 +6,5 @@ twine
 wheel
 setuptools
 nox
+charset-normalizer<3
+click<8.1.0

--- a/.kokoro/requirements.txt
+++ b/.kokoro/requirements.txt
@@ -93,11 +93,14 @@ cffi==1.15.1 \
 charset-normalizer==2.1.1 \
     --hash=sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845 \
     --hash=sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f
-    # via requests
+    # via
+    #   -r requirements.in
+    #   requests
 click==8.0.4 \
     --hash=sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1 \
     --hash=sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb
     # via
+    #   -r requirements.in
     #   gcp-docuploader
     #   gcp-releasetool
 colorlog==6.7.0 \
@@ -152,9 +155,9 @@ gcp-docuploader==0.6.3 \
     --hash=sha256:ba8c9d76b3bbac54b0311c503a373b00edc2dc02d6d54ea9507045adb8e870f7 \
     --hash=sha256:c0f5aaa82ce1854a386197e4e359b120ad6d4e57ae2c812fce42219a3288026b
     # via -r requirements.in
-gcp-releasetool==1.8.7 \
-    --hash=sha256:3d2a67c9db39322194afb3b427e9cb0476ce8f2a04033695f0aeb63979fc2b37 \
-    --hash=sha256:5e4d28f66e90780d77f3ecf1e9155852b0c3b13cbccb08ab07e66b2357c8da8d
+gcp-releasetool==1.10.0 \
+    --hash=sha256:72a38ca91b59c24f7e699e9227c90cbe4dd71b789383cb0164b088abae294c83 \
+    --hash=sha256:8c7c99320208383d4bb2b808c6880eb7a81424afe7cdba3c8d84b25f4f0e097d
     # via -r requirements.in
 google-api-core==2.8.2 \
     --hash=sha256:06f7244c640322b508b125903bb5701bebabce8832f85aba9335ec00b3d02edc \
@@ -162,9 +165,9 @@ google-api-core==2.8.2 \
     # via
     #   google-cloud-core
     #   google-cloud-storage
-google-auth==2.11.0 \
-    --hash=sha256:be62acaae38d0049c21ca90f27a23847245c9f161ff54ede13af2cb6afecbac9 \
-    --hash=sha256:ed65ecf9f681832298e29328e1ef0a3676e3732b2e56f41532d45f70a22de0fb
+google-auth==2.14.1 \
+    --hash=sha256:ccaa901f31ad5cbb562615eb8b664b3dd0bf5404a67618e642307f00613eda4d \
+    --hash=sha256:f5d8701633bebc12e0deea4df8abd8aff31c28b355360597f7f2ee60f2e4d016
     # via
     #   gcp-releasetool
     #   google-api-core
@@ -174,9 +177,9 @@ google-cloud-core==2.3.2 \
     --hash=sha256:8417acf6466be2fa85123441696c4badda48db314c607cf1e5d543fa8bdc22fe \
     --hash=sha256:b9529ee7047fd8d4bf4a2182de619154240df17fbe60ead399078c1ae152af9a
     # via google-cloud-storage
-google-cloud-storage==2.5.0 \
-    --hash=sha256:19a26c66c317ce542cea0830b7e787e8dac2588b6bfa4d3fd3b871ba16305ab0 \
-    --hash=sha256:382f34b91de2212e3c2e7b40ec079d27ee2e3dbbae99b75b1bcd8c63063ce235
+google-cloud-storage==2.6.0 \
+    --hash=sha256:104ca28ae61243b637f2f01455cc8a05e8f15a2a18ced96cb587241cdd3820f5 \
+    --hash=sha256:4ad0415ff61abdd8bb2ae81c1f8f7ec7d91a1011613f2db87c614c550f97bfe9
     # via gcp-docuploader
 google-crc32c==1.3.0 \
     --hash=sha256:04e7c220798a72fd0f08242bc8d7a05986b2a08a0573396187fd32c1dcdd58b3 \
@@ -227,9 +230,9 @@ google-resumable-media==2.3.3 \
     --hash=sha256:27c52620bd364d1c8116eaac4ea2afcbfb81ae9139fb3199652fcac1724bfb6c \
     --hash=sha256:5b52774ea7a829a8cdaa8bd2d4c3d4bc660c91b30857ab2668d0eb830f4ea8c5
     # via google-cloud-storage
-googleapis-common-protos==1.56.4 \
-    --hash=sha256:8eb2cbc91b69feaf23e32452a7ae60e791e09967d81d4fcc7fc388182d1bd394 \
-    --hash=sha256:c25873c47279387cfdcbdafa36149887901d36202cb645a0e4f29686bf6e4417
+googleapis-common-protos==1.57.0 \
+    --hash=sha256:27a849d6205838fb6cc3c1c21cb9800707a661bb21c6ce7fb13e99eb1f8a0c46 \
+    --hash=sha256:a9f4a1d7f6d9809657b7f1316a1aa527f6664891531bcfcc13b6696e685f443c
     # via google-api-core
 idna==3.3 \
     --hash=sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff \
@@ -240,6 +243,7 @@ importlib-metadata==4.12.0 \
     --hash=sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23
     # via
     #   -r requirements.in
+    #   keyring
     #   twine
 jaraco-classes==3.2.2 \
     --hash=sha256:6745f113b0b588239ceb49532aa09c3ebb947433ce311ef2f8e3ad64ebb74594 \
@@ -255,9 +259,9 @@ jinja2==3.1.2 \
     --hash=sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852 \
     --hash=sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61
     # via gcp-releasetool
-keyring==23.9.0 \
-    --hash=sha256:4c32a31174faaee48f43a7e2c7e9c3216ec5e95acf22a2bebfb4a1d05056ee44 \
-    --hash=sha256:98f060ec95ada2ab910c195a2d4317be6ef87936a766b239c46aa3c7aac4f0db
+keyring==23.11.0 \
+    --hash=sha256:3dd30011d555f1345dec2c262f0153f2f0ca6bca041fb1dc4588349bb4c0ac1e \
+    --hash=sha256:ad192263e2cdd5f12875dedc2da13534359a7e760e77f8d04b50968a821c2361
     # via
     #   gcp-releasetool
     #   twine
@@ -321,9 +325,9 @@ pkginfo==1.8.3 \
     --hash=sha256:848865108ec99d4901b2f7e84058b6e7660aae8ae10164e015a6dcf5b242a594 \
     --hash=sha256:a84da4318dd86f870a9447a8c98340aa06216bfc6f2b7bdc4b8766984ae1867c
     # via twine
-platformdirs==2.5.2 \
-    --hash=sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788 \
-    --hash=sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19
+platformdirs==2.5.4 \
+    --hash=sha256:1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7 \
+    --hash=sha256:af0276409f9a02373d540bf8480021a048711d572745aef4b7842dad245eba10
     # via virtualenv
 protobuf==3.20.1 \
     --hash=sha256:06059eb6953ff01e56a25cd02cca1a9649a75a7e65397b5b9b4e929ed71d10cf \
@@ -448,17 +452,17 @@ urllib3==1.26.12 \
     # via
     #   requests
     #   twine
-virtualenv==20.16.4 \
-    --hash=sha256:014f766e4134d0008dcaa1f95bafa0fb0f575795d07cae50b1bee514185d6782 \
-    --hash=sha256:035ed57acce4ac35c82c9d8802202b0e71adac011a511ff650cbcf9635006a22
+virtualenv==20.16.7 \
+    --hash=sha256:8691e3ff9387f743e00f6bb20f70121f5e4f596cae754531f2b3b3a1b1ac696e \
+    --hash=sha256:efd66b00386fdb7dbe4822d172303f40cd05e50e01740b19ea42425cbe653e29
     # via nox
 webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
     # via bleach
-wheel==0.37.1 \
-    --hash=sha256:4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a \
-    --hash=sha256:e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4
+wheel==0.38.4 \
+    --hash=sha256:965f5259b566725405b05e7cf774052044b1ed30119b5d586b2703aafe8719ac \
+    --hash=sha256:b60533f3f5d530e971d6737ca6d58681ee434818fab630c83a734bb10c083ce8
     # via -r requirements.in
 zipp==3.8.1 \
     --hash=sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2 \
@@ -466,7 +470,7 @@ zipp==3.8.1 \
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==65.2.0 \
-    --hash=sha256:7f4bc85450898a09f76ebf28b72fa25bc7111f6c7d665d514a60bba9c75ef2a9 \
-    --hash=sha256:a3ca5857c89f82f5c9410e8508cb32f4872a3bafd4aa7ae122a24ca33bccc750
+setuptools==65.5.1 \
+    --hash=sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31 \
+    --hash=sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f
     # via -r requirements.in

--- a/google/api_core/future/async_future.py
+++ b/google/api_core/future/async_future.py
@@ -95,7 +95,7 @@ class AsyncFuture(base.Future):
         if self._future.done():
             return
 
-        retry_ = self._retry.with_deadline(timeout)
+        retry_ = self._retry.with_timeout(timeout)
 
         try:
             await retry_(self._done_or_raise)()

--- a/google/api_core/future/polling.py
+++ b/google/api_core/future/polling.py
@@ -18,7 +18,7 @@ import abc
 import concurrent.futures
 
 from google.api_core import exceptions
-from google.api_core import retry
+from google.api_core import retry as retries
 from google.api_core.future import _helpers
 from google.api_core.future import base
 
@@ -29,14 +29,37 @@ class _OperationNotComplete(Exception):
     pass
 
 
-RETRY_PREDICATE = retry.if_exception_type(
+# DEPRECATED as it conflates RPC retry and polling concepts into one.
+# Use POLLING_PREDICATE instead to configure polling.
+RETRY_PREDICATE = retries.if_exception_type(
     _OperationNotComplete,
     exceptions.TooManyRequests,
     exceptions.InternalServerError,
     exceptions.BadGateway,
     exceptions.ServiceUnavailable,
 )
-DEFAULT_RETRY = retry.Retry(predicate=RETRY_PREDICATE)
+
+# DEPRECATED: use DEFAULT_POLLING to configure LRO polling logic. Construct
+# Retry object using its default values as a baseline for any custom retry logic
+# (not to be confused with polling logic).
+DEFAULT_RETRY = retries.Retry(predicate=RETRY_PREDICATE)
+
+# POLLING_PREDICATE is supposed to poll only on _OperationNotComplete.
+# Any RPC-specific errors (like ServiceUnavailable) will be handled
+# by retry logic (not to be confused with polling logic) which is triggered for
+# every polling RPC independently of polling logic but within its context.
+POLLING_PREDICATE = retries.if_exception_type(
+    _OperationNotComplete,
+)
+
+# Default polling configuration
+DEFAULT_POLLING = retries.Retry(
+    predicate=POLLING_PREDICATE,
+    initial=1.0,  # seconds
+    maximum=20.0,  # seconds
+    multiplier=1.5,
+    timeout=900,  # seconds
+)
 
 
 class PollingFuture(base.Future):
@@ -45,21 +68,29 @@ class PollingFuture(base.Future):
     The :meth:`done` method should be implemented by subclasses. The polling
     behavior will repeatedly call ``done`` until it returns True.
 
+    The actuall polling logic is encapsulated in :meth:`result` method. See
+    documentation for that method for details on how polling works.
+
     .. note::
 
         Privacy here is intended to prevent the final class from
         overexposing, not to prevent subclasses from accessing methods.
 
     Args:
-        retry (google.api_core.retry.Retry): The retry configuration used
-            when polling. This can be used to control how often :meth:`done`
-            is polled. Regardless of the retry's ``deadline``, it will be
-            overridden by the ``timeout`` argument to :meth:`result`.
+        polling (google.api_core.retry.Retry): The configuration used for polling.
+            This parameter controls how often :meth:`done` is polled. If the
+            ``timeout`` argument is specified in :meth:`result` method it will
+            override the ``polling.timeout`` property.
+        retry (google.api_core.retry.Retry): DEPRECATED use ``polling`` instead.
+            If set, it will override ``polling`` paremeter for backward
+            compatibility.
     """
 
-    def __init__(self, retry=DEFAULT_RETRY):
+    _DEFAULT_VALUE = object()
+
+    def __init__(self, polling=DEFAULT_POLLING, **kwargs):
         super(PollingFuture, self).__init__()
-        self._retry = retry
+        self._polling = kwargs.get("retry", polling)
         self._result = None
         self._exception = None
         self._result_set = False
@@ -69,11 +100,13 @@ class PollingFuture(base.Future):
         self._done_callbacks = []
 
     @abc.abstractmethod
-    def done(self, retry=DEFAULT_RETRY):
+    def done(self, retry=None):
         """Checks to see if the operation is complete.
 
         Args:
-            retry (google.api_core.retry.Retry): (Optional) How to retry the RPC.
+            retry (google.api_core.retry.Retry): (Optional) How to retry the
+                polling RPC (to not be confused with polling configuration. See
+                the documentation for :meth:`result` for details).
 
         Returns:
             bool: True if the operation is complete, False otherwise.
@@ -81,45 +114,136 @@ class PollingFuture(base.Future):
         # pylint: disable=redundant-returns-doc, missing-raises-doc
         raise NotImplementedError()
 
-    def _done_or_raise(self, retry=DEFAULT_RETRY):
+    def _done_or_raise(self, retry=None):
         """Check if the future is done and raise if it's not."""
-        kwargs = {} if retry is DEFAULT_RETRY else {"retry": retry}
-
-        if not self.done(**kwargs):
+        if not self.done(retry=retry):
             raise _OperationNotComplete()
 
     def running(self):
         """True if the operation is currently running."""
         return not self.done()
 
-    def _blocking_poll(self, timeout=None, retry=DEFAULT_RETRY):
-        """Poll and wait for the Future to be resolved.
+    def _blocking_poll(self, timeout=_DEFAULT_VALUE, retry=None, polling=None):
+        """Poll and wait for the Future to be resolved."""
 
-        Args:
-            timeout (int):
-                How long (in seconds) to wait for the operation to complete.
-                If None, wait indefinitely.
-        """
         if self._result_set:
             return
 
-        retry_ = self._retry.with_deadline(timeout)
+        polling = polling or self._polling
+        if timeout is not PollingFuture._DEFAULT_VALUE:
+            polling = polling.with_timeout(timeout)
 
         try:
-            kwargs = {} if retry is DEFAULT_RETRY else {"retry": retry}
-            retry_(self._done_or_raise)(**kwargs)
+            polling(self._done_or_raise)(retry=retry)
         except exceptions.RetryError:
             raise concurrent.futures.TimeoutError(
-                "Operation did not complete within the designated " "timeout."
+                f"Operation did not complete within the designated timeout of "
+                f"{polling.timeout} seconds."
             )
 
-    def result(self, timeout=None, retry=DEFAULT_RETRY):
-        """Get the result of the operation, blocking if necessary.
+    def result(self, timeout=_DEFAULT_VALUE, retry=None, polling=None):
+        """Get the result of the operation.
+
+        This method will poll for operation status periodically, blocking if
+        necessary. If you just want to make sure that this method does not block
+        for more than X seconds and you do not care about the nitty-gritty of
+        how this method operates, just call it with ``result(timeout=X)``. The
+        other parameters are for advanced use only.
+
+        Every call to this method is controlled by the following three
+        parameters, each of which has a specific, distinct role, even though all three
+        may look very similar: ``timeout``, ``retry`` and ``polling``. In most
+        cases users do not need to specify any custom values for any of these
+        parameters and may simply rely on default ones instead.
+
+        If you choose to specify custom parameters, please make sure you've
+        read the documentation below carefully.
+
+        First, please check :class:`google.api_core.retry.Retry`
+        class documentation for the proper definition of timeout and deadline
+        terms and for the definition the three different types of timeouts.
+        This class operates in terms of Retry Timeout and Polling Timeout. It
+        does not let customizing RPC timeout and the user is expected to rely on
+        default behavior for it.
+
+        The roles of each argument of this method are as follows:
+
+        ``timeout`` (int): (Optional) The Polling Timeout as defined in
+        :class:`google.api_core.retry.Retry`. If the operation does not complete
+        within this timeout an exception will be thrown. This parameter affects
+        neither Retry Timeout nor RPC Timeout.
+
+        ``retry`` (google.api_core.retry.Retry): (Optional) How to retry the
+        polling RPC. The ``retry.timeout`` property of this parameter is the
+        Retry Timeout as defined in :class:`google.api_core.retry.Retry`.
+        This parameter defines ONLY how the polling RPC call is retried
+        (i.e. what to do if the RPC we used for polling returned an error). It
+        does NOT define how the polling is done (i.e. how frequently and for
+        how long to call the polling RPC); use the ``polling`` parameter for that.
+        If a polling RPC throws and error and retrying it fails, the whole
+        future fails with the corresponding exception. If you want to tune which
+        server response error codes are not fatal for operation polling, use this
+        parameter to control that (``retry.predicate`` in particular).
+
+        ``polling`` (google.api_core.retry.Retry): (Optional) How often and
+        for how long to call the polling RPC periodically (i.e. what to do if
+        a polling rpc returned successfully but its returned result indicates
+        that the long running operation is not completed yet, so we need to
+        check it again at some point in future). This parameter does NOT define
+        how to retry each individual polling RPC in case of an error; use the
+        ``retry`` parameter for that. The ``polling.timeout`` of this parameter
+        is Polling Timeout as defined in as defined in
+        :class:`google.api_core.retry.Retry`.
+
+        For each of the arguments, there are also default values in place, which
+        will be used if a user does not specify their own. The default values
+        for the three parameters are not to be confused with the default values
+        for the corresponding arguments in this method (those serve as "not set"
+        markers for the resolution logic).
+
+        If ``timeout`` is provided (i.e.``timeout is not _DEFAULT VALUE``; note
+        the ``None`` value means "infinite timeout"), it will be used to control
+        the actual Polling Timeout. Otherwise, the ``polling.timeout`` value
+        will be used instead (see below for how the ``polling`` config itself
+        gets resolved). In other words, this parameter  effectively overrides
+        the ``polling.timeout`` value if specified. This is so to preserve
+        backward compatibility.
+
+        If ``retry`` is provided (i.e. ``retry is not None``) it will be used to
+        control retry behavior for the polling RPC and the ``retry.timeout``
+        will determine the Retry Timeout. If not provided, the
+        polling RPC will be called with whichever default retry config was
+        specified for the polling RPC at the moment of the construction of the
+        polling RPC's client. For example, if the polling RPC is
+        ``operations_client.get_operation()``, the ``retry`` parameter will be
+        controlling its retry behavior (not polling  behavior) and, if not
+        specified, that specific method (``operations_client.get_operation()``)
+        will be retried according to the default retry config provided during
+        creation of ``operations_client`` client instead. This argument exists
+        mainly for backward compatibility; users are very unlikely to ever need
+        to set this parameter explicitly.
+
+        If ``polling`` is provided (i.e. ``polling is not None``), it will be used
+        to controll the overall polling behavior and ``polling.timeout`` will
+        controll Polling Timeout unless it is overridden by ``timeout`` parameter
+        as described above. If not provided, the``polling`` parameter specified
+        during construction of this future (the ``polling`` argument in the
+        constructor) will be used instead. Note: since the ``timeout`` argument may
+        override ``polling.timeout`` value, this parameter should be viewed as
+        coupled with the ``timeout`` parameter as described above.
 
         Args:
-            timeout (int):
-                How long (in seconds) to wait for the operation to complete.
-                If None, wait indefinitely.
+            timeout (int): (Optional) How long (in seconds) to wait for the
+                operation to complete. If None, wait indefinitely.
+            retry (google.api_core.retry.Retry): (Optional) How to retry the
+                polling RPC. This defines ONLY how the polling RPC call is
+                retried (i.e. what to do if the RPC we used for polling returned
+                an error). It does  NOT define how the polling is done (i.e. how
+                frequently and for how long to call the polling RPC).
+            polling (google.api_core.retry.Retry): (Optional) How often and
+                for how long to call polling RPC periodically. This parameter
+                does NOT define how to retry each individual polling RPC call
+                (use the ``retry`` parameter for that).
 
         Returns:
             google.protobuf.Message: The Operation's result.
@@ -128,8 +252,8 @@ class PollingFuture(base.Future):
             google.api_core.GoogleAPICallError: If the operation errors or if
                 the timeout is reached before the operation completes.
         """
-        kwargs = {} if retry is DEFAULT_RETRY else {"retry": retry}
-        self._blocking_poll(timeout=timeout, **kwargs)
+
+        self._blocking_poll(timeout=timeout, retry=retry, polling=polling)
 
         if self._exception is not None:
             # pylint: disable=raising-bad-type
@@ -138,12 +262,18 @@ class PollingFuture(base.Future):
 
         return self._result
 
-    def exception(self, timeout=None):
+    def exception(self, timeout=_DEFAULT_VALUE):
         """Get the exception from the operation, blocking if necessary.
+
+        See the documentation for the :meth:`result` method for details on how
+        this method operates, as both ``result`` and this method rely on the
+        exact same polling logic. The only difference is that this method does
+        not accept ``retry`` and ``polling`` arguments but relies on the default ones
+        instead.
 
         Args:
             timeout (int): How long to wait for the operation to complete.
-                If None, wait indefinitely.
+            If None, wait indefinitely.
 
         Returns:
             Optional[google.api_core.GoogleAPICallError]: The operation's

--- a/google/api_core/gapic_v1/config.py
+++ b/google/api_core/gapic_v1/config.py
@@ -33,6 +33,9 @@ _MILLIS_PER_SECOND = 1000.0
 def _exception_class_for_grpc_status_name(name):
     """Returns the Google API exception class for a gRPC error code name.
 
+    DEPRECATED: use ``exceptions.exception_class_for_grpc_status`` method
+    directly instead.
+
     Args:
         name (str): The name of the gRPC status code, for example,
             ``UNAVAILABLE``.
@@ -46,6 +49,8 @@ def _exception_class_for_grpc_status_name(name):
 
 def _retry_from_retry_config(retry_params, retry_codes, retry_impl=retry.Retry):
     """Creates a Retry object given a gapic retry configuration.
+
+    DEPRECATED: instantiate retry and timeout classes directly instead.
 
     Args:
         retry_params (dict): The retry parameter values, for example::
@@ -81,6 +86,8 @@ def _retry_from_retry_config(retry_params, retry_codes, retry_impl=retry.Retry):
 def _timeout_from_retry_config(retry_params):
     """Creates a ExponentialTimeout object given a gapic retry configuration.
 
+    DEPRECATED: instantiate retry and timeout classes directly instead.
+
     Args:
         retry_params (dict): The retry parameter values, for example::
 
@@ -112,6 +119,8 @@ MethodConfig = collections.namedtuple("MethodConfig", ["retry", "timeout"])
 def parse_method_configs(interface_config, retry_impl=retry.Retry):
     """Creates default retry and timeout objects for each method in a gapic
     interface config.
+
+    DEPRECATED: instantiate retry and timeout classes directly instead.
 
     Args:
         interface_config (Mapping): The interface config section of the full

--- a/google/api_core/gapic_v1/routing_header.py
+++ b/google/api_core/gapic_v1/routing_header.py
@@ -20,21 +20,32 @@ requests, especially for services that are regional.
 Generally, these headers are specified as gRPC metadata.
 """
 
+from enum import Enum
 from urllib.parse import urlencode
 
 ROUTING_METADATA_KEY = "x-goog-request-params"
 
 
-def to_routing_header(params):
+def to_routing_header(params, qualified_enums=True):
     """Returns a routing header string for the given request parameters.
 
     Args:
         params (Mapping[str, Any]): A dictionary containing the request
             parameters used for routing.
+        qualified_enums (bool): Whether to represent enum values
+            as their type-qualified symbol names instead of as their
+            unqualified symbol names.
 
     Returns:
         str: The routing header string.
+
     """
+    if not qualified_enums:
+        if isinstance(params, dict):
+            tuples = params.items()
+        else:
+            tuples = params
+        params = [(x[0], x[1].name) if isinstance(x[1], Enum) else x for x in tuples]
     return urlencode(
         params,
         # Per Google API policy (go/api-url-encoding), / is not encoded.
@@ -42,16 +53,19 @@ def to_routing_header(params):
     )
 
 
-def to_grpc_metadata(params):
+def to_grpc_metadata(params, qualified_enums=True):
     """Returns the gRPC metadata containing the routing headers for the given
     request parameters.
 
     Args:
         params (Mapping[str, Any]): A dictionary containing the request
             parameters used for routing.
+        qualified_enums (bool): Whether to represent enum values
+            as their type-qualified symbol names instead of as their
+            unqualified symbol names.
 
     Returns:
         Tuple(str, str): The gRPC metadata containing the routing header key
             and value.
     """
-    return (ROUTING_METADATA_KEY, to_routing_header(params))
+    return (ROUTING_METADATA_KEY, to_routing_header(params, qualified_enums))

--- a/google/api_core/grpc_helpers.py
+++ b/google/api_core/grpc_helpers.py
@@ -311,7 +311,7 @@ def create_channel(
         default_host=default_host,
     )
 
-    if HAS_GRPC_GCP:
+    if HAS_GRPC_GCP:  # pragma: NO COVER
         return grpc_gcp.secure_channel(target, composite_credentials, **kwargs)
     return grpc.secure_channel(target, composite_credentials, **kwargs)
 

--- a/google/api_core/operations_v1/operations_client.py
+++ b/google/api_core/operations_v1/operations_client.py
@@ -37,9 +37,11 @@ automatically by another client class to deal with operations.
 
 import functools
 
+from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
 from google.api_core import page_iterator
-from google.api_core.operations_v1 import operations_client_config
+from google.api_core import retry as retries
+from google.api_core import timeout as timeouts
 from google.longrunning import operations_pb2
 
 
@@ -54,39 +56,44 @@ class OperationsClient(object):
             the default configuration is used.
     """
 
-    def __init__(self, channel, client_config=operations_client_config.config):
+    def __init__(self, channel, client_config=None):
         # Create the gRPC client stub.
         self.operations_stub = operations_pb2.OperationsStub(channel)
 
-        # Create all wrapped methods using the interface configuration.
-        # The interface config contains all of the default settings for retry
-        # and timeout for each RPC method.
-        interfaces = client_config["interfaces"]
-        interface_config = interfaces["google.longrunning.Operations"]
-        method_configs = gapic_v1.config.parse_method_configs(interface_config)
+        default_retry = retries.Retry(
+            initial=0.1,  # seconds
+            maximum=60.0,  # seconds
+            multiplier=1.3,
+            predicate=retries.if_exception_type(
+                core_exceptions.DeadlineExceeded,
+                core_exceptions.ServiceUnavailable,
+            ),
+            timeout=600.0,  # seconds
+        )
+        default_timeout = timeouts.TimeToDeadlineTimeout(timeout=600.0)
 
         self._get_operation = gapic_v1.method.wrap_method(
             self.operations_stub.GetOperation,
-            default_retry=method_configs["GetOperation"].retry,
-            default_timeout=method_configs["GetOperation"].timeout,
+            default_retry=default_retry,
+            default_timeout=default_timeout,
         )
 
         self._list_operations = gapic_v1.method.wrap_method(
             self.operations_stub.ListOperations,
-            default_retry=method_configs["ListOperations"].retry,
-            default_timeout=method_configs["ListOperations"].timeout,
+            default_retry=default_retry,
+            default_timeout=default_timeout,
         )
 
         self._cancel_operation = gapic_v1.method.wrap_method(
             self.operations_stub.CancelOperation,
-            default_retry=method_configs["CancelOperation"].retry,
-            default_timeout=method_configs["CancelOperation"].timeout,
+            default_retry=default_retry,
+            default_timeout=default_timeout,
         )
 
         self._delete_operation = gapic_v1.method.wrap_method(
             self.operations_stub.DeleteOperation,
-            default_retry=method_configs["DeleteOperation"].retry,
-            default_timeout=method_configs["DeleteOperation"].timeout,
+            default_retry=default_retry,
+            default_timeout=default_timeout,
         )
 
     # Service calls

--- a/google/api_core/operations_v1/operations_client_config.py
+++ b/google/api_core/operations_v1/operations_client_config.py
@@ -14,6 +14,7 @@
 
 """gapic configuration for the googe.longrunning.operations client."""
 
+# DEPRECATED: retry and timeout classes are instantiated directly
 config = {
     "interfaces": {
         "google.longrunning.Operations": {

--- a/google/api_core/operations_v1/transports/__init__.py
+++ b/google/api_core/operations_v1/transports/__init__.py
@@ -14,14 +14,13 @@
 # limitations under the License.
 #
 from collections import OrderedDict
-from typing import Dict, Type
 
 from .base import OperationsTransport
 from .rest import OperationsRestTransport
 
 
 # Compile a registry of transports.
-_transport_registry = OrderedDict()  # type: Dict[str, Type[OperationsTransport]]
+_transport_registry = OrderedDict()
 _transport_registry["rest"] = OperationsRestTransport
 
 __all__ = (

--- a/google/api_core/timeout.py
+++ b/google/api_core/timeout.py
@@ -14,8 +14,9 @@
 
 """Decorators for applying timeout arguments to functions.
 
-These decorators are used to wrap API methods to apply either a constant
-or exponential timeout argument.
+These decorators are used to wrap API methods to apply either a
+Deadline-dependent (recommended), constant (DEPRECATED) or exponential
+(DEPRECATED) timeout argument.
 
 For example, imagine an API method that can take a while to return results,
 such as one that might block until a resource is ready:
@@ -66,8 +67,68 @@ _DEFAULT_TIMEOUT_MULTIPLIER = 2.0
 _DEFAULT_DEADLINE = None
 
 
+class TimeToDeadlineTimeout(object):
+    """A decorator that decreases timeout set for an RPC based on how much time
+    has left till its deadline. The deadline is calculated as
+    ``now + initial_timeout`` when this decorator is first called for an rpc.
+
+    In other words this decorator implements deadline semantics in terms of a
+    sequence of decreasing timeouts t0 > t1 > t2 ... tn >= 0.
+
+    Args:
+        timeout (Optional[float]): the timeout (in seconds) to applied to the
+            wrapped function. If `None`, the target function is expected to
+            never timeout.
+    """
+
+    def __init__(self, timeout=None, clock=datetime_helpers.utcnow):
+        self._timeout = timeout
+        self._clock = clock
+
+    def __call__(self, func):
+        """Apply the timeout decorator.
+
+        Args:
+            func (Callable): The function to apply the timeout argument to.
+                This function must accept a timeout keyword argument.
+
+        Returns:
+            Callable: The wrapped function.
+        """
+
+        first_attempt_timestamp = self._clock().timestamp()
+
+        @functools.wraps(func)
+        def func_with_timeout(*args, **kwargs):
+            """Wrapped function that adds timeout."""
+
+            remaining_timeout = self._timeout
+            if remaining_timeout is not None:
+                # All calculations are in seconds
+                now_timestamp = self._clock().timestamp()
+
+                # To avoid usage of nonlocal but still have round timeout
+                # numbers for first attempt (in most cases the only attempt made
+                # for an RPC.
+                if now_timestamp - first_attempt_timestamp < 0.001:
+                    now_timestamp = first_attempt_timestamp
+
+                time_since_first_attempt = now_timestamp - first_attempt_timestamp
+                # Avoid setting negative timeout
+                kwargs["timeout"] = max(0, self._timeout - time_since_first_attempt)
+
+            return func(*args, **kwargs)
+
+        return func_with_timeout
+
+    def __str__(self):
+        return "<TimeToDeadlineTimeout timeout={:.1f}>".format(self._timeout)
+
+
 class ConstantTimeout(object):
     """A decorator that adds a constant timeout argument.
+
+    DEPRECATED: use ``TimeToDeadlineTimeout`` instead.
 
     This is effectively equivalent to
     ``functools.partial(func, timeout=timeout)``.
@@ -139,6 +200,9 @@ def _exponential_timeout_generator(initial, maximum, multiplier, deadline):
 
 class ExponentialTimeout(object):
     """A decorator that adds an exponentially increasing timeout argument.
+
+    DEPRECATED: the concept of incrementing timeout exponentially has been
+    deprecated. Use ``TimeToDeadlineTimeout`` instead.
 
     This is useful if a function is called multiple times. Each time the
     function is called this decorator will calculate a new timeout parameter

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,7 +26,7 @@ BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 # Black and flake8 clash on the syntax for ignoring flake8's F401 in this file.
 BLACK_EXCLUDES = ["--exclude", "^/google/api_core/operations_v1/__init__.py"]
 
-DEFAULT_PYTHON_VERSION = "3.7"
+DEFAULT_PYTHON_VERSION = "3.10"
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 # 'docfx' is excluded since it only needs to run in 'docs-presubmit'
@@ -95,7 +95,16 @@ def default(session, install_grpc=True):
     )
 
     # Install all test dependencies, then install this package in-place.
-    session.install("dataclasses", "mock", "pytest", "pytest-cov", "pytest-xdist")
+    session.install(
+        "dataclasses",
+        "mock",
+        # Revert to just "pytest" once
+        # https://github.com/pytest-dev/pytest/issues/10451 is fixed
+        "pytest<7.2.0",
+        "pytest-cov",
+        "pytest-xdist",
+    )
+
     if install_grpc:
         session.install("-e", ".[grpc]", "-c", constraints_path)
     else:
@@ -192,7 +201,7 @@ def mypy(session):
     session.run("mypy", "google", "tests")
 
 
-@nox.session(python="3.8")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def cover(session):
     """Run the final coverage report.
 
@@ -204,12 +213,12 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python="3.8")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def docs(session):
     """Build the docs for this library."""
 
     session.install("-e", ".[grpc]")
-    session.install("sphinx==4.0.1", "alabaster", "recommonmark")
+    session.install("sphinx==4.2.0", "alabaster", "recommonmark")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -94,7 +94,6 @@ def default(session, install_grpc=True):
         CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
     )
 
-    # Install all test dependencies, then install this package in-place.
     session.install(
         "dataclasses",
         "mock",

--- a/noxfile.py
+++ b/noxfile.py
@@ -61,7 +61,7 @@ def lint(session):
     Returns a failure if the linters find linting errors or sufficiently
     serious code quality issues.
     """
-    session.install("flake8", "flake8-import-order", BLACK_VERSION)
+    session.install("flake8", BLACK_VERSION)
     session.install(".")
     session.run(
         "black",
@@ -171,7 +171,7 @@ def unit_wo_grpc(session):
     default(session, install_grpc=False)
 
 
-@nox.session(python="3.8")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
 
@@ -212,7 +212,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+@nox.session(python="3.9")
 def docs(session):
     """Build the docs for this library."""
 
@@ -234,7 +234,7 @@ def docs(session):
     )
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def docfx(session):
     """Build the docfx yaml files for this library."""
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -47,8 +47,6 @@ s.replace(
 """,
 )
 
-s.replace(".github/workflows/lint.yml", "python-version: \"3.10\"", "python-version: \"3.7\"")
-
 python.configure_previous_major_version_branches()
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)

--- a/tests/asyncio/operations_v1/test_operations_async_client.py
+++ b/tests/asyncio/operations_v1/test_operations_async_client.py
@@ -17,7 +17,7 @@ import pytest
 
 try:
     from grpc import aio
-except ImportError:
+except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 from google.api_core import grpc_helpers_async

--- a/tests/asyncio/test_grpc_helpers_async.py
+++ b/tests/asyncio/test_grpc_helpers_async.py
@@ -18,11 +18,11 @@ import pytest  # noqa: I202
 try:
     import grpc
     from grpc import aio
-except ImportError:
+except ImportError:  # pragma: NO COVER
     grpc = aio = None
 
 
-if grpc is None:
+if grpc is None:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 

--- a/tests/asyncio/test_operation_async.py
+++ b/tests/asyncio/test_operation_async.py
@@ -18,7 +18,7 @@ import pytest
 
 try:
     import grpc  # noqa: F401
-except ImportError:
+except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 from google.api_core import exceptions

--- a/tests/asyncio/test_retry_async.py
+++ b/tests/asyncio/test_retry_async.py
@@ -116,7 +116,7 @@ async def test_retry_target_deadline_exceeded(utcnow, sleep):
         await retry_async.retry_target(target, predicate, range(10), deadline=10)
 
     assert exc_info.value.cause == exception
-    assert exc_info.match("Deadline of 10.0s exceeded")
+    assert exc_info.match("Timeout of 10.0s exceeded")
     assert exc_info.match("last exception: meep")
     assert target.call_count == 2
 
@@ -253,7 +253,7 @@ class TestAsyncRetry:
         assert re.match(
             (
                 r"<AsyncRetry predicate=<function.*?if_exception_type.*?>, "
-                r"initial=1.0, maximum=60.0, multiplier=2.0, deadline=120.0, "
+                r"initial=1.0, maximum=60.0, multiplier=2.0, timeout=120.0, "
                 r"on_error=None>"
             ),
             str(retry_),
@@ -276,8 +276,7 @@ class TestAsyncRetry:
         target.assert_called_once_with("meep")
         sleep.assert_not_called()
 
-    # Make uniform return half of its maximum, which is the calculated sleep time.
-    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n / 2.0)
+    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n)
     @mock.patch("asyncio.sleep", autospec=True)
     @pytest.mark.asyncio
     async def test___call___and_execute_retry(self, sleep, uniform):
@@ -302,8 +301,7 @@ class TestAsyncRetry:
         sleep.assert_called_once_with(retry_._initial)
         assert on_error.call_count == 1
 
-    # Make uniform return half of its maximum, which is the calculated sleep time.
-    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n / 2.0)
+    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n)
     @mock.patch("asyncio.sleep", autospec=True)
     @pytest.mark.asyncio
     async def test___call___and_execute_retry_hitting_deadline(self, sleep, uniform):
@@ -376,8 +374,7 @@ class TestAsyncRetry:
         sleep.assert_not_called()
         _some_function.assert_not_called()
 
-    # Make uniform return half of its maximum, which is the calculated sleep time.
-    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n / 2.0)
+    @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n)
     @mock.patch("asyncio.sleep", autospec=True)
     @pytest.mark.asyncio
     async def test___init___when_retry_is_executed(self, sleep, uniform):

--- a/tests/unit/gapic/test_routing_header.py
+++ b/tests/unit/gapic/test_routing_header.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from enum import Enum
+
 import pytest
 
 try:
@@ -33,6 +35,35 @@ def test_to_routing_header_with_slashes():
     params = [("name", "me/ep"), ("book.read", "1&2")]
     value = routing_header.to_routing_header(params)
     assert value == "name=me/ep&book.read=1%262"
+
+
+def test_enum_fully_qualified():
+    class Message:
+        class Color(Enum):
+            RED = 1
+            GREEN = 2
+            BLUE = 3
+
+    params = [("color", Message.Color.RED)]
+    value = routing_header.to_routing_header(params)
+    assert value == "color=Color.RED"
+    value = routing_header.to_routing_header(params, qualified_enums=True)
+    assert value == "color=Color.RED"
+
+
+def test_enum_nonqualified():
+    class Message:
+        class Color(Enum):
+            RED = 1
+            GREEN = 2
+            BLUE = 3
+
+    params = [("color", Message.Color.RED), ("num", 5)]
+    value = routing_header.to_routing_header(params, qualified_enums=False)
+    assert value == "color=RED&num=5"
+    params = {"color": Message.Color.RED, "num": 5}
+    value = routing_header.to_routing_header(params, qualified_enums=False)
+    assert value == "color=RED&num=5"
 
 
 def test_to_grpc_metadata():

--- a/tests/unit/operations_v1/test_operations_client.py
+++ b/tests/unit/operations_v1/test_operations_client.py
@@ -16,12 +16,13 @@ import pytest
 
 try:
     import grpc  # noqa: F401
-except ImportError:
+except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 from google.api_core import grpc_helpers
 from google.api_core import operations_v1
 from google.api_core import page_iterator
+from google.api_core.operations_v1 import operations_client_config
 from google.longrunning import operations_pb2
 from google.protobuf import empty_pb2
 
@@ -96,3 +97,7 @@ def test_cancel_operation():
     ].metadata
     assert len(channel.CancelOperation.requests) == 1
     assert channel.CancelOperation.requests[0].name == "name"
+
+
+def test_operations_client_config():
+    assert operations_client_config.config["interfaces"]

--- a/tests/unit/operations_v1/test_operations_rest_client.py
+++ b/tests/unit/operations_v1/test_operations_rest_client.py
@@ -20,7 +20,7 @@ import pytest
 
 try:
     import grpc  # noqa: F401
-except ImportError:
+except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 from requests import Response  # noqa I201
 from requests.sessions import Session
@@ -121,7 +121,7 @@ def test_operations_client_from_service_account_info(client_class):
         assert client.transport._credentials == creds
         assert isinstance(client, client_class)
 
-        assert client.transport._host == "longrunning.googleapis.com:443"
+        assert client.transport._host == "https://longrunning.googleapis.com"
 
 
 @pytest.mark.parametrize(
@@ -160,7 +160,7 @@ def test_operations_client_from_service_account_file(client_class):
         assert client.transport._credentials == creds
         assert isinstance(client, client_class)
 
-        assert client.transport._host == "longrunning.googleapis.com:443"
+        assert client.transport._host == "https://longrunning.googleapis.com"
 
 
 def test_operations_client_get_transport_class():
@@ -465,10 +465,7 @@ def test_list_operations_rest(
 
         actual_args = req.call_args
         assert actual_args.args[0] == "GET"
-        assert (
-            actual_args.args[1]
-            == "https://longrunning.googleapis.com:443/v3/operations"
-        )
+        assert actual_args.args[1] == "https://longrunning.googleapis.com/v3/operations"
         assert actual_args.kwargs["params"] == [
             ("filter", "my_filter"),
             ("pageSize", 10),
@@ -574,7 +571,7 @@ def test_get_operation_rest(
     assert actual_args.args[0] == "GET"
     assert (
         actual_args.args[1]
-        == "https://longrunning.googleapis.com:443/v3/operations/sample1"
+        == "https://longrunning.googleapis.com/v3/operations/sample1"
     )
 
     # Establish that the response is the type that we expect.
@@ -591,13 +588,11 @@ def test_get_operation_rest_failure():
         response_value.status_code = 400
         mock_request = mock.MagicMock()
         mock_request.method = "GET"
-        mock_request.url = (
-            "https://longrunning.googleapis.com:443/v1/operations/sample1"
-        )
+        mock_request.url = "https://longrunning.googleapis.com/v1/operations/sample1"
         response_value.request = mock_request
         req.return_value = response_value
         with pytest.raises(core_exceptions.GoogleAPIError):
-            client.get_operation("operations/sample1")
+            client.get_operation("sammple0/operations/sample1")
 
 
 def test_delete_operation_rest(
@@ -619,7 +614,7 @@ def test_delete_operation_rest(
         assert actual_args.args[0] == "DELETE"
         assert (
             actual_args.args[1]
-            == "https://longrunning.googleapis.com:443/v3/operations/sample1"
+            == "https://longrunning.googleapis.com/v3/operations/sample1"
         )
 
 
@@ -631,13 +626,11 @@ def test_delete_operation_rest_failure():
         response_value.status_code = 400
         mock_request = mock.MagicMock()
         mock_request.method = "DELETE"
-        mock_request.url = (
-            "https://longrunning.googleapis.com:443/v1/operations/sample1"
-        )
+        mock_request.url = "https://longrunning.googleapis.com/v1/operations/sample1"
         response_value.request = mock_request
         req.return_value = response_value
         with pytest.raises(core_exceptions.GoogleAPIError):
-            client.delete_operation(name="operations/sample1")
+            client.delete_operation(name="sample0/operations/sample1")
 
 
 def test_cancel_operation_rest(transport: str = "rest"):
@@ -657,7 +650,7 @@ def test_cancel_operation_rest(transport: str = "rest"):
         assert actual_args.args[0] == "POST"
         assert (
             actual_args.args[1]
-            == "https://longrunning.googleapis.com:443/v3/operations/sample1:cancel"
+            == "https://longrunning.googleapis.com/v3/operations/sample1:cancel"
         )
 
 
@@ -670,12 +663,12 @@ def test_cancel_operation_rest_failure():
         mock_request = mock.MagicMock()
         mock_request.method = "POST"
         mock_request.url = (
-            "https://longrunning.googleapis.com:443/v1/operations/sample1:cancel"
+            "https://longrunning.googleapis.com/v1/operations/sample1:cancel"
         )
         response_value.request = mock_request
         req.return_value = response_value
         with pytest.raises(core_exceptions.GoogleAPIError):
-            client.cancel_operation(name="operations/sample1")
+            client.cancel_operation(name="sample0/operations/sample1")
 
 
 def test_credentials_transport_error():
@@ -825,7 +818,7 @@ def test_operations_host_no_port():
             api_endpoint="longrunning.googleapis.com"
         ),
     )
-    assert client.transport._host == "longrunning.googleapis.com:443"
+    assert client.transport._host == "https://longrunning.googleapis.com"
 
 
 def test_operations_host_with_port():
@@ -835,7 +828,7 @@ def test_operations_host_with_port():
             api_endpoint="longrunning.googleapis.com:8000"
         ),
     )
-    assert client.transport._host == "longrunning.googleapis.com:8000"
+    assert client.transport._host == "https://longrunning.googleapis.com:8000"
 
 
 def test_common_billing_account_path():

--- a/tests/unit/test_bidi.py
+++ b/tests/unit/test_bidi.py
@@ -22,7 +22,7 @@ import pytest
 
 try:
     import grpc
-except ImportError:
+except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 from google.api_core import bidi

--- a/tests/unit/test_client_info.py
+++ b/tests/unit/test_client_info.py
@@ -15,7 +15,7 @@
 
 try:
     import grpc
-except ImportError:
+except ImportError:  # pragma: NO COVER
     grpc = None
 
 from google.api_core import client_info
@@ -26,9 +26,9 @@ def test_constructor_defaults():
 
     assert info.python_version is not None
 
-    if grpc is not None:
+    if grpc is not None:  # pragma: NO COVER
         assert info.grpc_version is not None
-    else:
+    else:  # pragma: NO COVER
         assert info.grpc_version is None
 
     assert info.api_core_version is not None

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -22,7 +22,7 @@ import requests
 try:
     import grpc
     from grpc_status import rpc_status
-except ImportError:
+except ImportError:  # pragma: NO COVER
     grpc = rpc_status = None
 
 from google.api_core import exceptions

--- a/tests/unit/test_general_helpers.py
+++ b/tests/unit/test_general_helpers.py
@@ -1,0 +1,13 @@
+# Copyright 2022, Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit/test_grpc_helpers.py
+++ b/tests/unit/test_grpc_helpers.py
@@ -17,7 +17,7 @@ import pytest
 
 try:
     import grpc
-except ImportError:
+except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 from google.api_core import exceptions
@@ -365,7 +365,7 @@ def test_create_channel_implicit(grpc_secure_channel, default, composite_creds_c
 
     default.assert_called_once_with(scopes=None, default_scopes=None)
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -400,7 +400,7 @@ def test_create_channel_implicit_with_default_host(
         mock.sentinel.credentials, mock.sentinel.Request, default_host=default_host
     )
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -427,7 +427,7 @@ def test_create_channel_implicit_with_ssl_creds(
     composite_creds_call.assert_called_once_with(ssl_creds, mock.ANY)
     composite_creds = composite_creds_call.return_value
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -452,7 +452,7 @@ def test_create_channel_implicit_with_scopes(
 
     default.assert_called_once_with(scopes=["one", "two"], default_scopes=None)
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -477,7 +477,7 @@ def test_create_channel_implicit_with_default_scopes(
 
     default.assert_called_once_with(scopes=None, default_scopes=["three", "four"])
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -509,7 +509,7 @@ def test_create_channel_explicit(grpc_secure_channel, auth_creds, composite_cred
 
     assert channel is grpc_secure_channel.return_value
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -533,7 +533,7 @@ def test_create_channel_explicit_scoped(grpc_secure_channel, composite_creds_cal
 
     assert channel is grpc_secure_channel.return_value
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -561,7 +561,7 @@ def test_create_channel_explicit_default_scopes(
 
     assert channel is grpc_secure_channel.return_value
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -587,7 +587,7 @@ def test_create_channel_explicit_with_quota_project(
 
     assert channel is grpc_secure_channel.return_value
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -616,7 +616,7 @@ def test_create_channel_with_credentials_file(
 
     assert channel is grpc_secure_channel.return_value
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -648,7 +648,7 @@ def test_create_channel_with_credentials_file_and_scopes(
 
     assert channel is grpc_secure_channel.return_value
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -680,7 +680,7 @@ def test_create_channel_with_credentials_file_and_default_scopes(
 
     assert channel is grpc_secure_channel.return_value
 
-    if grpc_helpers.HAS_GRPC_GCP:
+    if grpc_helpers.HAS_GRPC_GCP:  # pragma: NO COVER
         grpc_secure_channel.assert_called_once_with(target, composite_creds, None)
     else:
         grpc_secure_channel.assert_called_once_with(target, composite_creds)
@@ -690,7 +690,7 @@ def test_create_channel_with_credentials_file_and_default_scopes(
     not grpc_helpers.HAS_GRPC_GCP, reason="grpc_gcp module not available"
 )
 @mock.patch("grpc_gcp.secure_channel")
-def test_create_channel_with_grpc_gcp(grpc_gcp_secure_channel):
+def test_create_channel_with_grpc_gcp(grpc_gcp_secure_channel):  # pragma: NO COVER
     target = "example.com:443"
     scopes = ["test_scope"]
 

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -18,7 +18,7 @@ import pytest
 
 try:
     import grpc  # noqa: F401
-except ImportError:
+except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 from google.api_core import exceptions

--- a/tests/unit/test_timeout.py
+++ b/tests/unit/test_timeout.py
@@ -17,11 +17,11 @@ import itertools
 
 import mock
 
-from google.api_core import timeout
+from google.api_core import timeout as timeouts
 
 
 def test__exponential_timeout_generator_base_2():
-    gen = timeout._exponential_timeout_generator(1.0, 60.0, 2.0, deadline=None)
+    gen = timeouts._exponential_timeout_generator(1.0, 60.0, 2.0, deadline=None)
 
     result = list(itertools.islice(gen, 8))
     assert result == [1, 2, 4, 8, 16, 32, 60, 60]
@@ -34,7 +34,7 @@ def test__exponential_timeout_generator_base_deadline(utcnow):
         datetime.datetime.min + datetime.timedelta(seconds=n) for n in range(15)
     ]
 
-    gen = timeout._exponential_timeout_generator(1.0, 60.0, 2.0, deadline=30.0)
+    gen = timeouts._exponential_timeout_generator(1.0, 60.0, 2.0, deadline=30.0)
 
     result = list(itertools.islice(gen, 14))
     # Should grow until the cumulative time is > 30s, then start decreasing as
@@ -42,22 +42,105 @@ def test__exponential_timeout_generator_base_deadline(utcnow):
     assert result == [1, 2, 4, 8, 16, 24, 23, 22, 21, 20, 19, 18, 17, 16]
 
 
-class TestConstantTimeout(object):
+class TestTimeToDeadlineTimeout(object):
     def test_constructor(self):
-        timeout_ = timeout.ConstantTimeout()
+        timeout_ = timeouts.TimeToDeadlineTimeout()
         assert timeout_._timeout is None
 
     def test_constructor_args(self):
-        timeout_ = timeout.ConstantTimeout(42.0)
+        timeout_ = timeouts.TimeToDeadlineTimeout(42.0)
         assert timeout_._timeout == 42.0
 
     def test___str__(self):
-        timeout_ = timeout.ConstantTimeout(1)
+        timeout_ = timeouts.TimeToDeadlineTimeout(1)
+        assert str(timeout_) == "<TimeToDeadlineTimeout timeout=1.0>"
+
+    def test_apply(self):
+        target = mock.Mock(spec=["__call__", "__name__"], __name__="target")
+
+        datetime.datetime.utcnow()
+        datetime.timedelta(seconds=1)
+
+        now = datetime.datetime.utcnow()
+
+        times = [
+            now,
+            now + datetime.timedelta(seconds=0.0009),
+            now + datetime.timedelta(seconds=1),
+            now + datetime.timedelta(seconds=39),
+            now + datetime.timedelta(seconds=42),
+            now + datetime.timedelta(seconds=43),
+        ]
+
+        def _clock():
+            return times.pop(0)
+
+        timeout_ = timeouts.TimeToDeadlineTimeout(42.0, _clock)
+        wrapped = timeout_(target)
+
+        wrapped()
+        target.assert_called_with(timeout=42.0)
+        wrapped()
+        target.assert_called_with(timeout=41.0)
+        wrapped()
+        target.assert_called_with(timeout=3.0)
+        wrapped()
+        target.assert_called_with(timeout=0.0)
+        wrapped()
+        target.assert_called_with(timeout=0.0)
+
+    def test_apply_no_timeout(self):
+        target = mock.Mock(spec=["__call__", "__name__"], __name__="target")
+
+        datetime.datetime.utcnow()
+        datetime.timedelta(seconds=1)
+
+        now = datetime.datetime.utcnow()
+
+        times = [
+            now,
+            now + datetime.timedelta(seconds=0.0009),
+            now + datetime.timedelta(seconds=1),
+            now + datetime.timedelta(seconds=2),
+        ]
+
+        def _clock():
+            return times.pop(0)
+
+        timeout_ = timeouts.TimeToDeadlineTimeout(clock=_clock)
+        wrapped = timeout_(target)
+
+        wrapped()
+        target.assert_called_with()
+        wrapped()
+        target.assert_called_with()
+
+    def test_apply_passthrough(self):
+        target = mock.Mock(spec=["__call__", "__name__"], __name__="target")
+        timeout_ = timeouts.TimeToDeadlineTimeout(42.0)
+        wrapped = timeout_(target)
+
+        wrapped(1, 2, meep="moop")
+
+        target.assert_called_once_with(1, 2, meep="moop", timeout=42.0)
+
+
+class TestConstantTimeout(object):
+    def test_constructor(self):
+        timeout_ = timeouts.ConstantTimeout()
+        assert timeout_._timeout is None
+
+    def test_constructor_args(self):
+        timeout_ = timeouts.ConstantTimeout(42.0)
+        assert timeout_._timeout == 42.0
+
+    def test___str__(self):
+        timeout_ = timeouts.ConstantTimeout(1)
         assert str(timeout_) == "<ConstantTimeout timeout=1.0>"
 
     def test_apply(self):
         target = mock.Mock(spec=["__call__", "__name__"], __name__="target")
-        timeout_ = timeout.ConstantTimeout(42.0)
+        timeout_ = timeouts.ConstantTimeout(42.0)
         wrapped = timeout_(target)
 
         wrapped()
@@ -66,7 +149,7 @@ class TestConstantTimeout(object):
 
     def test_apply_passthrough(self):
         target = mock.Mock(spec=["__call__", "__name__"], __name__="target")
-        timeout_ = timeout.ConstantTimeout(42.0)
+        timeout_ = timeouts.ConstantTimeout(42.0)
         wrapped = timeout_(target)
 
         wrapped(1, 2, meep="moop")
@@ -76,30 +159,30 @@ class TestConstantTimeout(object):
 
 class TestExponentialTimeout(object):
     def test_constructor(self):
-        timeout_ = timeout.ExponentialTimeout()
-        assert timeout_._initial == timeout._DEFAULT_INITIAL_TIMEOUT
-        assert timeout_._maximum == timeout._DEFAULT_MAXIMUM_TIMEOUT
-        assert timeout_._multiplier == timeout._DEFAULT_TIMEOUT_MULTIPLIER
-        assert timeout_._deadline == timeout._DEFAULT_DEADLINE
+        timeout_ = timeouts.ExponentialTimeout()
+        assert timeout_._initial == timeouts._DEFAULT_INITIAL_TIMEOUT
+        assert timeout_._maximum == timeouts._DEFAULT_MAXIMUM_TIMEOUT
+        assert timeout_._multiplier == timeouts._DEFAULT_TIMEOUT_MULTIPLIER
+        assert timeout_._deadline == timeouts._DEFAULT_DEADLINE
 
     def test_constructor_args(self):
-        timeout_ = timeout.ExponentialTimeout(1, 2, 3, 4)
+        timeout_ = timeouts.ExponentialTimeout(1, 2, 3, 4)
         assert timeout_._initial == 1
         assert timeout_._maximum == 2
         assert timeout_._multiplier == 3
         assert timeout_._deadline == 4
 
     def test_with_timeout(self):
-        original_timeout = timeout.ExponentialTimeout()
+        original_timeout = timeouts.ExponentialTimeout()
         timeout_ = original_timeout.with_deadline(42)
         assert original_timeout is not timeout_
-        assert timeout_._initial == timeout._DEFAULT_INITIAL_TIMEOUT
-        assert timeout_._maximum == timeout._DEFAULT_MAXIMUM_TIMEOUT
-        assert timeout_._multiplier == timeout._DEFAULT_TIMEOUT_MULTIPLIER
+        assert timeout_._initial == timeouts._DEFAULT_INITIAL_TIMEOUT
+        assert timeout_._maximum == timeouts._DEFAULT_MAXIMUM_TIMEOUT
+        assert timeout_._multiplier == timeouts._DEFAULT_TIMEOUT_MULTIPLIER
         assert timeout_._deadline == 42
 
     def test___str__(self):
-        timeout_ = timeout.ExponentialTimeout(1, 2, 3, 4)
+        timeout_ = timeouts.ExponentialTimeout(1, 2, 3, 4)
         assert str(timeout_) == (
             "<ExponentialTimeout initial=1.0, maximum=2.0, multiplier=3.0, "
             "deadline=4.0>"
@@ -107,7 +190,7 @@ class TestExponentialTimeout(object):
 
     def test_apply(self):
         target = mock.Mock(spec=["__call__", "__name__"], __name__="target")
-        timeout_ = timeout.ExponentialTimeout(1, 10, 2)
+        timeout_ = timeouts.ExponentialTimeout(1, 10, 2)
         wrapped = timeout_(target)
 
         wrapped()
@@ -121,7 +204,7 @@ class TestExponentialTimeout(object):
 
     def test_apply_passthrough(self):
         target = mock.Mock(spec=["__call__", "__name__"], __name__="target")
-        timeout_ = timeout.ExponentialTimeout(42.0, 100, 2)
+        timeout_ = timeouts.ExponentialTimeout(42.0, 100, 2)
         wrapped = timeout_(target)
 
         wrapped(1, 2, meep="moop")


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: Allow representing enums with their unqualified symbolic names in headers in v1 branch (#462)
fix: Major refactoring of Polling, Retry and Timeout logic in v1 branch (#465)
END_COMMIT_OVERRIDE



Including notes from PR #462 
> This is in response to https://freeman.vc/notes/aws-vs-gcp-reliability-is-wildly-different, which triggered an investigation of the whole Polling/Retry/Timeout behavior in Python GAPIC clients and revealed many fundamental >flaws in its implementation.
>
>To properly describe the refactoring in this PR we need to stick to a rigorous terminology, as vague definitions of retries, timeouts, polling and related concepts seems to be the main source of the present bugs and overall >confusion among both groups: users of the library and creators of the library. Please check the updated (in this PR) documentation of the `google.api_core.retry.Retry` class and the `google.api_core.future.polling.Polling.result>()` method for the proper definitions and context.
>
>Note, the overall semantics around Polling, Retry and Timeout remains quite confusing even after refactoring (although it is now more or less rigorously defined), but it was as clean as I could make it while still maintaining >backward compatibility of the whole library.
>
>The quick summary of the changes in this PR:
>
>1) Properly define and fix the application of Deadline and Timeout concepts. Please check the updated documentation for the `google.api_core.retry.Retry` class for the actual definitions. Originally the `deadline` has been used >to represent timeouts conflating the two concepts. As result this PR replaces `deadline` arguments with `timeout` ones in as backward-compatible manner as possible (i.e. backward compatible in all practical applications).
>
>2) Properly define RPC Timeout, Retry Timeout and Polling Timeout and how a generic Timeout concept (aka Logical Timeout) is mapped to one of those depending on the context. Please check `google.api_core.retry.Retry` class >documentation for details.
>
>3) Properly define and fix the application of Retry and Polling concepts. Please check the updated documentation for `google.api_core.future.polling.PollingFuture.result()` for details.
>
>4) Separate `retry` and `polling` configurations for Polling future, as these are two different concepts (although both operating on `Retry` class). Originally both retry and polling configurations were controlled by a single >`retry` parameter, merging configuration regarding how "rpc error responses" and how "operation not completed" responses are supposed to be handled.
>
>5) For the following config properties - `Retry` (including `Retry Timeout`), `Polling` (including `Polling Timeout`) and `RPC Timeout` - fix and properly define how each of the above properties gets configured and which config >gets precedence in case of a conflict (check `PollingFuture.result()` method documentation for details). Each of those properties can be specified as follows: directly provided by the user for each call, specified during gapic >generation time from config values in `grpc_service_config.json` file (for Retry and RPC Timeout) and `gapic.yaml` file (for Polling Timeout), or be provided as a hard-coded basic default values in python-api-core library >itself. This alo includes fixing the per-call polling config propagation logic (the polling/retry configs supplied to `PollingFuture.result()` used to be ignored for actual call).
>
>6) Deprecate `ExponentialTimeout`, `ConstantTimeout` and related logic as those are outdated concepts and are not consistent with the other GAPIC Languages. Replace it with `TimeToDeadlineTimeout` to be consistent with how the >rest of the languages do it.
>
>7) Deprecate `google.api_core.operations_v1.config` as it is an outdated concept and self-inconsistent (as all gapic clients provide configuraiton in code). The configs are directly provided in code instead.
>
>8) Switch randomized delay calculation from `delay` being treated as expected value for randomized_delay to `delay` being treated as maximum value for `randomized_delay` (i.e. the new expected valud for `randomized_delay` is >`delay / 2`). See the `exponential_sleep_generator()` method implementation for details. This is needed to make Python implementation of retries and polling exponential backoff consistent with the rest of GAPIC languages. Also >fix the uncontrollable growth of `delay` value (since it is a subject of exponential growth, the `delay` value was quickly reaching "infinity" value, and the whole thing was not failing simply due to python being a very >forgiving language which forgives multiplying "infinity" by a number (`inf * number = inf`) binstead of simply overflowing to a (most likely) negative number). Also essentially rollback  the https://github.com/googleapis/>python-api-core/commit/52f12af027568ddeae7fb6b1e3d2111cce1bac08 change, since that is inconsistent with the other languages and damages uniform distibution of retry delays artificially shifting  their concentration towards the >end of timeout.
>
>9) Fix url construction in `OperationsRestTransport`. Without this fix the polling logic for REST transport was completely broken (is not affecting Compute client, as that one has custom LRO).
>
>10) Last but not least: change the default values for Polling logic to be the following: `initial=1.0` (same as before), `maximum=20.0` (was `60`), `multiplier=1.5` (was `2.0`), `timeout=900` (was `120`, but due to timeout >resolution logic was actually None (i.e. infinity)). This, in conjunction with changed calculation of randomized delay (i.e. its expected value now being  `delay / 2`) overall makes polling logic much less aggressive in terms of >increasing delays between each polling iteration, making LRO return much earlier for users on average, but still keeping a healthy balance between strain put on both client and server by polling and responsiveness of LROs for >user.
>
>*The design doc summarising all the changes and reasons for them is in progress.
>
>In addition to the timeout/retry fixes, this PR has some other non-related technical fixes: 
>- Fix and improve code coverage (and explicitly disables lines which are not supposed to be covered) 
>- Define `Python 3.10` as the default python version used in CI.
>- Upgrade to Sphinx 4.2.0, as it is the one supporting Python 3.10
>