### PR TITLE
test: switch to regex rather than asserting against whole object

### DIFF
--- a/tests/unit/test_client_options.py
+++ b/tests/unit/test_client_options.py
@@ -145,7 +145,21 @@ def test_from_dict_bad_argument():
 
 
 def test_repr():
+    expected_keys = set(
+        [
+            "api_endpoint",
+            "client_cert_source",
+            "client_encrypted_cert_source",
+            "quota_project_id",
+            "credentials_file",
+            "scopes",
+            "api_key",
+            "api_audience",
+        ]
+    )
     options = client_options.ClientOptions(api_endpoint="foo.googleapis.com")
     options_repr = repr(options)
+    options_keys = vars(options).keys()
     assert match(r"ClientOptions:", options_repr)
     assert match(r".*'api_endpoint': 'foo.googleapis.com'.*", options_repr)
+    assert options_keys == expected_keys

--- a/tests/unit/test_client_options.py
+++ b/tests/unit/test_client_options.py
@@ -144,16 +144,18 @@ def test_from_dict_bad_argument():
 
 
 def test_repr():
-    expected_keys = set([
-        "api_endpoint",
-        "client_cert_source",
-        "client_encrypted_cert_source",
-        "quota_project_id",
-        "credentials_file",
-        "scopes",
-        "api_key",
-        "api_audience"
-    ])
+    expected_keys = set(
+        [
+            "api_endpoint",
+            "client_cert_source",
+            "client_encrypted_cert_source",
+            "quota_project_id",
+            "credentials_file",
+            "scopes",
+            "api_key",
+            "api_audience",
+        ]
+    )
     options = client_options.ClientOptions(api_endpoint="foo.googleapis.com")
     options_keys = vars(options).keys()
 

--- a/tests/unit/test_client_options.py
+++ b/tests/unit/test_client_options.py
@@ -148,4 +148,4 @@ def test_repr():
     options = client_options.ClientOptions(api_endpoint="foo.googleapis.com")
     options_repr = repr(options)
     assert match(r"ClientOptions:", options_repr)
-    assert match(r".*api_endpoint.*foo.googleapis.com", options_repr)
+    assert match(r".*'api_endpoint': 'foo.googleapis.com'.*", options_repr)

--- a/tests/unit/test_client_options.py
+++ b/tests/unit/test_client_options.py
@@ -161,3 +161,6 @@ def test_repr():
 
     assert options_keys == expected_keys
     assert options.api_endpoint == "foo.googleapis.com"
+    # Assert options default to None.
+    assert options.client_encrypted_cert_source is None
+    assert options.api_key is None

--- a/tests/unit/test_client_options.py
+++ b/tests/unit/test_client_options.py
@@ -144,10 +144,18 @@ def test_from_dict_bad_argument():
 
 
 def test_repr():
+    expected_keys = set([
+        "api_endpoint",
+        "client_cert_source",
+        "client_encrypted_cert_source",
+        "quota_project_id",
+        "credentials_file",
+        "scopes",
+        "api_key",
+        "api_audience"
+    ])
     options = client_options.ClientOptions(api_endpoint="foo.googleapis.com")
+    options_keys = vars(options).keys()
 
-    assert (
-        repr(options)
-        == "ClientOptions: {'api_endpoint': 'foo.googleapis.com', 'client_cert_source': None, 'client_encrypted_cert_source': None, 'api_key': None}"
-        or "ClientOptions: {'client_encrypted_cert_source': None, 'client_cert_source': None, 'api_endpoint': 'foo.googleapis.com', 'api_key': None}"
-    )
+    assert options_keys == expected_keys
+    assert options.api_endpoint == "foo.googleapis.com"

--- a/tests/unit/test_client_options.py
+++ b/tests/unit/test_client_options.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from re import match
 import pytest
 
 from google.api_core import client_options
@@ -143,24 +144,8 @@ def test_from_dict_bad_argument():
         )
 
 
-def test_vars():
-    expected_keys = set(
-        [
-            "api_endpoint",
-            "client_cert_source",
-            "client_encrypted_cert_source",
-            "quota_project_id",
-            "credentials_file",
-            "scopes",
-            "api_key",
-            "api_audience",
-        ]
-    )
+def test_repr():
     options = client_options.ClientOptions(api_endpoint="foo.googleapis.com")
-    options_keys = vars(options).keys()
-
-    assert options_keys == expected_keys
-    assert options.api_endpoint == "foo.googleapis.com"
-    # Assert options default to None.
-    assert options.client_encrypted_cert_source is None
-    assert options.api_key is None
+    options_repr = repr(options)
+    assert match(r'ClientOptions:', options_repr)
+    assert match(r'.*api_endpoint.*foo.googleapis.com', options_repr)

--- a/tests/unit/test_client_options.py
+++ b/tests/unit/test_client_options.py
@@ -147,5 +147,5 @@ def test_from_dict_bad_argument():
 def test_repr():
     options = client_options.ClientOptions(api_endpoint="foo.googleapis.com")
     options_repr = repr(options)
-    assert match(r'ClientOptions:', options_repr)
-    assert match(r'.*api_endpoint.*foo.googleapis.com', options_repr)
+    assert match(r"ClientOptions:", options_repr)
+    assert match(r".*api_endpoint.*foo.googleapis.com", options_repr)

--- a/tests/unit/test_client_options.py
+++ b/tests/unit/test_client_options.py
@@ -143,7 +143,7 @@ def test_from_dict_bad_argument():
         )
 
 
-def test_repr():
+def test_vars():
     expected_keys = set(
         [
             "api_endpoint",


### PR DESCRIPTION
The goal of this test is to assert against the helper:

```python
    def __repr__(self):
        return "ClientOptions: " + repr(self.__dict__)
```

Rather than asserting against the whole object which is fragile, this just uses a regex to make sure that we've populated the prefix and the keys.

Fixes #449, #492

---

FYI: here's the commit for the original test, which I believe a simple regex that asserts the basic structure of the serialized object is closer to the spirit of https://github.com/googleapis/python-api-core/commit/b6cea3c2d4e2d1a35af5246a88a87133bb5eada5