### PR TITLE
fix: drop usage of distutils

### DIFF
--- a/google/api_core/operations_v1/abstract_operations_client.py
+++ b/google/api_core/operations_v1/abstract_operations_client.py
@@ -293,14 +293,14 @@ class AbstractOperationsClient(metaclass=AbstractOperationsClientMeta):
             client_options = client_options_lib.ClientOptions()
 
         # Create SSL credentials for mutual TLS if needed.
-        use_client_cert = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false")
-        if use_client_cert.lower() not in ("true", "false"):
+        use_client_cert = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false").lower()
+        if use_client_cert not in ("true", "false"):
             raise ValueError(
                 "Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be either `true` or `false`"
             )
         client_cert_source_func = None
         is_mtls = False
-        if use_client_cert.lower() == "true":
+        if use_client_cert == "true":
             if client_options.client_cert_source:
                 is_mtls = True
                 client_cert_source_func = client_options.client_cert_source

--- a/google/api_core/operations_v1/abstract_operations_client.py
+++ b/google/api_core/operations_v1/abstract_operations_client.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 from collections import OrderedDict
-from distutils import util
 import os
 import re
 from typing import Dict, Optional, Sequence, Tuple, Type, Union
@@ -293,14 +292,14 @@ class AbstractOperationsClient(metaclass=AbstractOperationsClientMeta):
         if client_options is None:
             client_options = client_options_lib.ClientOptions()
 
-        # Create SSL credentials for mutual TLS if needed.
-        use_client_cert = bool(
-            util.strtobool(os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false"))
-        )
 
+        # Create SSL credentials for mutual TLS if needed.
+        use_client_cert = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false")
+        if use_client_cert.lower() not in ("true", "false"):
+            raise ValueError("Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be either `true` or `false`")
         client_cert_source_func = None
         is_mtls = False
-        if use_client_cert:
+        if use_client_cert.lower() == "true":
             if client_options.client_cert_source:
                 is_mtls = True
                 client_cert_source_func = client_options.client_cert_source

--- a/google/api_core/operations_v1/abstract_operations_client.py
+++ b/google/api_core/operations_v1/abstract_operations_client.py
@@ -293,7 +293,9 @@ class AbstractOperationsClient(metaclass=AbstractOperationsClientMeta):
             client_options = client_options_lib.ClientOptions()
 
         # Create SSL credentials for mutual TLS if needed.
-        use_client_cert = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false").lower()
+        use_client_cert = os.getenv(
+            "GOOGLE_API_USE_CLIENT_CERTIFICATE", "false"
+        ).lower()
         if use_client_cert not in ("true", "false"):
             raise ValueError(
                 "Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be either `true` or `false`"

--- a/google/api_core/operations_v1/abstract_operations_client.py
+++ b/google/api_core/operations_v1/abstract_operations_client.py
@@ -292,11 +292,12 @@ class AbstractOperationsClient(metaclass=AbstractOperationsClientMeta):
         if client_options is None:
             client_options = client_options_lib.ClientOptions()
 
-
         # Create SSL credentials for mutual TLS if needed.
         use_client_cert = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false")
         if use_client_cert.lower() not in ("true", "false"):
-            raise ValueError("Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be either `true` or `false`")
+            raise ValueError(
+                "Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be either `true` or `false`"
+            )
         client_cert_source_func = None
         is_mtls = False
         if use_client_cert.lower() == "true":


### PR DESCRIPTION
Fixes https://github.com/googleapis/python-api-core/issues/507 🦕

- Raises `ValueError` if the format of the `GOOGLE_API_USE_CLIENT_CERTIFICATE` is not as defined below
https://github.com/googleapis/python-api-core/blob/405272c05f8c6d20e242c6172b01f78f0fd3bf32/google/api_core/operations_v1/abstract_operations_client.py#L275-L280

This is the same behaviour that exists in `gapic-generator-python` here https://github.com/googleapis/gapic-generator-python/blob/45f18a69454bcff68c0f98535c68fbdb4e09db1d/gapic/templates/%25namespace/%25name_%25version/%25sub/services/%25service/client.py.j2#L253-L256