### PR TITLE
fix: add warning to retry target to avoid incorrect usage

### DIFF
--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -140,6 +140,7 @@ async def test_retry_target_warning_for_retry(utcnow, sleep):
     target = mock.AsyncMock(spec=["__call__"])
 
     with pytest.warns(Warning) as exc_info:
+        # Note: predicate is just a filler and doesn't affect the test
         retry.retry_target(target, predicate, range(10), None)
     
     assert len(exc_info) == 2

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -128,6 +128,7 @@ def test_retry_target_non_retryable_error(utcnow, sleep):
     assert exc_info.value == exception
     sleep.assert_not_called()
 
+
 @mock.patch("asyncio.sleep", autospec=True)
 @mock.patch(
     "google.api_core.datetime_helpers.utcnow",
@@ -142,7 +143,7 @@ async def test_retry_target_warning_for_retry(utcnow, sleep):
     with pytest.warns(Warning) as exc_info:
         # Note: predicate is just a filler and doesn't affect the test
         retry.retry_target(target, predicate, range(10), None)
-    
+
     assert len(exc_info) == 2
     assert str(exc_info[0].message) == retry._ASYNC_RETRY_WARNING
     sleep.assert_not_called()

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -128,6 +128,24 @@ def test_retry_target_non_retryable_error(utcnow, sleep):
     assert exc_info.value == exception
     sleep.assert_not_called()
 
+@mock.patch("asyncio.sleep", autospec=True)
+@mock.patch(
+    "google.api_core.datetime_helpers.utcnow",
+    return_value=datetime.datetime.min,
+    autospec=True,
+)
+@pytest.mark.asyncio
+async def test_retry_target_warning_for_retry(utcnow, sleep):
+    predicate = retry.if_exception_type(ValueError)
+    target = mock.AsyncMock(spec=["__call__"])
+
+    with pytest.warns(Warning) as exc_info:
+        retry.retry_target(target, predicate, range(10), None)
+    
+    assert len(exc_info) == 2
+    assert str(exc_info[0].message) == retry._ASYNC_RETRY_WARNING
+    sleep.assert_not_called()
+
 
 @mock.patch("time.sleep", autospec=True)
 @mock.patch("google.api_core.datetime_helpers.utcnow", autospec=True)


### PR DESCRIPTION
Fixes #542 🦕
