### PR TITLE
feat: support with_call for wrapped rpcs

### DIFF
--- a/tests/unit/gapic/test_method.py
+++ b/tests/unit/gapic/test_method.py
@@ -217,7 +217,7 @@ def test_wrap_method_with_call():
 
 def test_wrap_method_with_call_not_supported():
     """Raises an error if wrapped callable doesn't have with_call method."""
-    method = lambda: None
+    method = lambda: None  # noqa: E731
 
     with pytest.raises(ValueError) as exc_info:
         google.api_core.gapic_v1.method.wrap_method(method, with_call=True)

--- a/tests/unit/gapic/test_method.py
+++ b/tests/unit/gapic/test_method.py
@@ -202,6 +202,7 @@ def test_wrap_method_with_overriding_timeout_as_a_number():
     assert result == 42
     method.assert_called_once_with(timeout=22, metadata=mock.ANY)
 
+
 def test_wrap_method_with_call():
     method = mock.Mock()
     mock_call = mock.Mock()
@@ -212,6 +213,7 @@ def test_wrap_method_with_call():
     assert len(result) == 2
     assert result[0] == 42
     assert result[1] == mock_call
+
 
 def test_wrap_method_with_call_not_supported():
     """Raises an error if wrapped callable doesn't have with_call method."""

--- a/tests/unit/gapic/test_method.py
+++ b/tests/unit/gapic/test_method.py
@@ -201,3 +201,22 @@ def test_wrap_method_with_overriding_timeout_as_a_number():
 
     assert result == 42
     method.assert_called_once_with(timeout=22, metadata=mock.ANY)
+
+def test_wrap_method_with_call():
+    method = mock.Mock()
+    mock_call = mock.Mock()
+    method.with_call.return_value = 42, mock_call
+
+    wrapped_method = google.api_core.gapic_v1.method.wrap_method(method, with_call=True)
+    result = wrapped_method()
+    assert len(result) == 2
+    assert result[0] == 42
+    assert result[1] == mock_call
+
+def test_wrap_method_with_call_not_supported():
+    """Raises an error if wrapped callable doesn't have with_call method."""
+    method = lambda: None
+
+    with pytest.raises(ValueError) as exc_info:
+        google.api_core.gapic_v1.method.wrap_method(method, with_call=True)
+    assert "with_call=True is only supported for unary calls" in str(exc_info.value)


### PR DESCRIPTION
Most grpc calls return a `grpc.Call` object, that contains trailing metadata and other useful information. You can then `await` (for async unary rpcs) or iterate over (for streaming rpcs) the Call object to get the proto results of the rpc.

This is not the case for unary synchronous calls, because there is no intermediate object. Calling the rpc results in the value directly. The grpc library provides [`with_call` methods](https://grpc.github.io/grpc/python/grpc.html#grpc.UnaryUnaryMultiCallable.with_call) for this reason, which return a tuple of the rpc result and the Call object.

Currently, the gapic wrapper does not provide a way to access this data

This PR solves the issue by adding `with_call` to the `wrap_method` function, which will is passed down to the grpc callable