### PR TITLE
fix: replace deprecated `datetime.datetime.utcnow()`

### DIFF
--- a/google/api_core/datetime_helpers.py
+++ b/google/api_core/datetime_helpers.py
@@ -42,7 +42,7 @@ _RFC3339_NANOS = re.compile(
 
 def utcnow():
     """A :meth:`datetime.datetime.utcnow()` alias to allow mocking in tests."""
-    return datetime.datetime.utcnow()
+    return datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
 
 
 def to_milliseconds(value):

--- a/noxfile.py
+++ b/noxfile.py
@@ -143,7 +143,7 @@ def default(session, install_grpc=True):
     session.run(*pytest_args)
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"])
 def unit(session):
     """Run the unit test suite."""
     default(session)

--- a/tests/asyncio/test_retry_async.py
+++ b/tests/asyncio/test_retry_async.py
@@ -280,7 +280,6 @@ class TestAsyncRetry:
     @mock.patch("asyncio.sleep", autospec=True)
     @pytest.mark.asyncio
     async def test___call___and_execute_retry(self, sleep, uniform):
-
         on_error = mock.Mock(spec=["__call__"], side_effect=[None])
         retry_ = retry_async.AsyncRetry(
             predicate=retry_async.if_exception_type(ValueError)
@@ -305,7 +304,6 @@ class TestAsyncRetry:
     @mock.patch("asyncio.sleep", autospec=True)
     @pytest.mark.asyncio
     async def test___call___and_execute_retry_hitting_deadline(self, sleep, uniform):
-
         on_error = mock.Mock(spec=["__call__"], side_effect=[None] * 10)
         retry_ = retry_async.AsyncRetry(
             predicate=retry_async.if_exception_type(ValueError),
@@ -315,7 +313,7 @@ class TestAsyncRetry:
             deadline=9.9,
         )
 
-        utcnow = datetime.datetime.utcnow()
+        utcnow = datetime.datetime.now(tz=datetime.timezone.utc)
         utcnow_patcher = mock.patch(
             "google.api_core.datetime_helpers.utcnow", return_value=utcnow
         )

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -361,7 +361,6 @@ class TestRetry(object):
     @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n)
     @mock.patch("time.sleep", autospec=True)
     def test___call___and_execute_retry(self, sleep, uniform):
-
         on_error = mock.Mock(spec=["__call__"], side_effect=[None])
         retry_ = retry.Retry(predicate=retry.if_exception_type(ValueError))
 
@@ -383,7 +382,6 @@ class TestRetry(object):
     @mock.patch("random.uniform", autospec=True, side_effect=lambda m, n: n)
     @mock.patch("time.sleep", autospec=True)
     def test___call___and_execute_retry_hitting_deadline(self, sleep, uniform):
-
         on_error = mock.Mock(spec=["__call__"], side_effect=[None] * 10)
         retry_ = retry.Retry(
             predicate=retry.if_exception_type(ValueError),
@@ -393,7 +391,7 @@ class TestRetry(object):
             deadline=30.9,
         )
 
-        utcnow = datetime.datetime.utcnow()
+        utcnow = datetime.datetime.now(tz=datetime.timezone.utc)
         utcnow_patcher = mock.patch(
             "google.api_core.datetime_helpers.utcnow", return_value=utcnow
         )

--- a/tests/unit/test_timeout.py
+++ b/tests/unit/test_timeout.py
@@ -58,10 +58,10 @@ class TestTimeToDeadlineTimeout(object):
     def test_apply(self):
         target = mock.Mock(spec=["__call__", "__name__"], __name__="target")
 
-        datetime.datetime.utcnow()
+        datetime.datetime.now(tz=datetime.timezone.utc)
         datetime.timedelta(seconds=1)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
 
         times = [
             now,
@@ -92,10 +92,10 @@ class TestTimeToDeadlineTimeout(object):
     def test_apply_no_timeout(self):
         target = mock.Mock(spec=["__call__", "__name__"], __name__="target")
 
-        datetime.datetime.utcnow()
+        datetime.datetime.now(tz=datetime.timezone.utc)
         datetime.timedelta(seconds=1)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
 
         times = [
             now,


### PR DESCRIPTION
`datetime.datetime.utcnow()` is deprecated in Python 3.12.

Fixes #540
