### PR TITLE
feat: add type annotations to wrapped grpc calls

### DIFF
--- a/google/api_core/grpc_helpers.py
+++ b/google/api_core/grpc_helpers.py
@@ -58,6 +58,7 @@ _LOGGER = logging.getLogger(__name__)
 # denotes the type yielded from streaming calls
 S = TypeVar("S")
 
+
 def _patch_callable_name(callable_):
     """Fix-up gRPC callable attributes.
 

--- a/google/api_core/grpc_helpers.py
+++ b/google/api_core/grpc_helpers.py
@@ -148,6 +148,7 @@ class _StreamingResponseIterator(grpc.Call, Generic[S]):
         return self._wrapped.trailing_metadata()
 
 
+# public type alias denoting the return type of streaming gapic calls
 GrpcStream = _StreamingResponseIterator[S]
 
 

--- a/google/api_core/grpc_helpers.py
+++ b/google/api_core/grpc_helpers.py
@@ -58,6 +58,7 @@ _LOGGER = logging.getLogger(__name__)
 # denotes the type yielded from streaming calls
 S = TypeVar("S")
 
+
 def _patch_callable_name(callable_):
     """Fix-up gRPC callable attributes.
 
@@ -165,9 +166,7 @@ def _wrap_stream_errors(callable_):
             # hidden flag to see if pre-fetching is disabled.
             # https://github.com/googleapis/python-pubsub/issues/93#issuecomment-630762257
             prefetch_first = getattr(callable_, "_prefetch_first_result_", True)
-            return GrpcStream(
-                result, prefetch_first_result=prefetch_first
-            )
+            return GrpcStream(result, prefetch_first_result=prefetch_first)
         except grpc.RpcError as exc:
             raise exceptions.from_grpc_error(exc) from exc
 

--- a/google/api_core/grpc_helpers.py
+++ b/google/api_core/grpc_helpers.py
@@ -55,8 +55,8 @@ _STREAM_WRAP_CLASSES = (grpc.UnaryStreamMultiCallable, grpc.StreamStreamMultiCal
 
 _LOGGER = logging.getLogger(__name__)
 
-# denotes the type yielded from streaming calls
-S = TypeVar("S")
+# denotes the proto response type for grpc calls
+P = TypeVar("P")
 
 
 def _patch_callable_name(callable_):
@@ -83,7 +83,7 @@ def _wrap_unary_errors(callable_):
     return error_remapped_callable
 
 
-class _StreamingResponseIterator(Generic[S], grpc.Call):
+class _StreamingResponseIterator(Generic[P], grpc.Call):
     def __init__(self, wrapped, prefetch_first_result=True):
         self._wrapped = wrapped
 
@@ -101,11 +101,11 @@ class _StreamingResponseIterator(Generic[S], grpc.Call):
             # ignore stop iteration at this time. This should be handled outside of retry.
             pass
 
-    def __iter__(self) -> Iterator[S]:
+    def __iter__(self) -> Iterator[P]:
         """This iterator is also an iterable that returns itself."""
         return self
 
-    def __next__(self) -> S:
+    def __next__(self) -> P:
         """Get the next response from the stream.
 
         Returns:
@@ -149,7 +149,7 @@ class _StreamingResponseIterator(Generic[S], grpc.Call):
 
 
 # public type alias denoting the return type of streaming gapic calls
-GrpcStream = _StreamingResponseIterator[S]
+GrpcStream = _StreamingResponseIterator[P]
 
 
 def _wrap_stream_errors(callable_):

--- a/google/api_core/grpc_helpers.py
+++ b/google/api_core/grpc_helpers.py
@@ -83,7 +83,7 @@ def _wrap_unary_errors(callable_):
     return error_remapped_callable
 
 
-class _StreamingResponseIterator(grpc.Call, Generic[S]):
+class _StreamingResponseIterator(Generic[S], grpc.Call):
     def __init__(self, wrapped, prefetch_first_result=True):
         self._wrapped = wrapped
 

--- a/google/api_core/grpc_helpers_async.py
+++ b/google/api_core/grpc_helpers_async.py
@@ -154,7 +154,7 @@ class _WrappedStreamStreamCall(
     """Wrapped StreamStreamCall to map exceptions."""
 
 
-# public type alias denoting the return type of streaming gapic calls
+# public type alias denoting the return type of async streaming gapic calls
 GrpcAsyncStream = _WrappedStreamResponseMixin[S]
 # public type alias denoting the return type of unary gapic calls
 AwaitableGrpcCall = _WrappedUnaryResponseMixin[U]

--- a/google/api_core/grpc_helpers_async.py
+++ b/google/api_core/grpc_helpers_async.py
@@ -21,7 +21,7 @@ functions. This module is implementing the same surface with AsyncIO semantics.
 import asyncio
 import functools
 
-from typing import Generic, Iterator, AsyncGenerator, Awaitable, TypeVar, Any, Union
+from typing import Generic, Iterator, AsyncGenerator, TypeVar
 
 import grpc
 from grpc import aio

--- a/google/api_core/grpc_helpers_async.py
+++ b/google/api_core/grpc_helpers_async.py
@@ -81,7 +81,7 @@ class _WrappedCall(aio.Call):
         except grpc.RpcError as rpc_error:
             raise exceptions.from_grpc_error(rpc_error) from rpc_error
 
-class _WrappedUnaryResponseMixin(_WrappedCall, Generic[U]):
+class _WrappedUnaryResponseMixin(Generic[U], _WrappedCall):
     def __await__(self) -> Generator[Any, None, U]:
         try:
             response = yield from self._call.__await__()
@@ -90,7 +90,7 @@ class _WrappedUnaryResponseMixin(_WrappedCall, Generic[U]):
             raise exceptions.from_grpc_error(rpc_error) from rpc_error
 
 
-class _WrappedStreamResponseMixin(_WrappedCall, Generic[S]):
+class _WrappedStreamResponseMixin(Generic[S], _WrappedCall):
     def __init__(self):
         self._wrapped_async_generator = None
 
@@ -154,7 +154,7 @@ class _WrappedStreamStreamCall(
 
 
 # public type denoting the return type of streaming gapic calls
-AwaitableGrpcAsyncStream = Union[_WrappedUnaryStreamCall[S], _WrappedStreamStreamCall[S]]
+AwaitableGrpcStream = Union[_WrappedUnaryStreamCall[S], _WrappedStreamStreamCall[S]]
 # public type denoting the return type of unary gapic calls
 AwaitableGrpcCall = Union[_WrappedUnaryUnaryCall[U], _WrappedStreamUnaryCall[U]]
 

--- a/google/api_core/grpc_helpers_async.py
+++ b/google/api_core/grpc_helpers_async.py
@@ -154,9 +154,9 @@ class _WrappedStreamStreamCall(
     """Wrapped StreamStreamCall to map exceptions."""
 
 
-# public type denoting the return type of streaming gapic calls
+# public type alias denoting the return type of streaming gapic calls
 GrpcAsyncStream = _WrappedStreamResponseMixin[S]
-# public type denoting the return type of unary gapic calls
+# public type alias denoting the return type of unary gapic calls
 AwaitableGrpcCall = _WrappedUnaryResponseMixin[U]
 
 

--- a/google/api_core/grpc_helpers_async.py
+++ b/google/api_core/grpc_helpers_async.py
@@ -155,9 +155,9 @@ class _WrappedStreamStreamCall(
 
 
 # public type denoting the return type of streaming gapic calls
-AwaitableGrpcStream = Union[_WrappedUnaryStreamCall[S], _WrappedStreamStreamCall[S]]
+GrpcAsyncStream = _WrappedStreamResponseMixin[S]
 # public type denoting the return type of unary gapic calls
-AwaitableGrpcCall = Union[_WrappedUnaryUnaryCall[U], _WrappedStreamUnaryCall[U]]
+AwaitableGrpcCall = _WrappedUnaryResponseMixin[U]
 
 
 def _wrap_unary_errors(callable_):

--- a/google/api_core/grpc_helpers_async.py
+++ b/google/api_core/grpc_helpers_async.py
@@ -21,7 +21,7 @@ functions. This module is implementing the same surface with AsyncIO semantics.
 import asyncio
 import functools
 
-from typing import Generic, Generator, AsyncGenerator, Awaitable, TypeVar, Any, Union
+from typing import Generic, Iterator, AsyncGenerator, Awaitable, TypeVar, Any, Union
 
 import grpc
 from grpc import aio
@@ -83,7 +83,7 @@ class _WrappedCall(aio.Call):
 
 
 class _WrappedUnaryResponseMixin(Generic[U], _WrappedCall):
-    def __await__(self) -> Generator[Any, None, U]:
+    def __await__(self) -> Iterator[U]:
         try:
             response = yield from self._call.__await__()
             return response

--- a/google/api_core/grpc_helpers_async.py
+++ b/google/api_core/grpc_helpers_async.py
@@ -81,6 +81,7 @@ class _WrappedCall(aio.Call):
         except grpc.RpcError as rpc_error:
             raise exceptions.from_grpc_error(rpc_error) from rpc_error
 
+
 class _WrappedUnaryResponseMixin(Generic[U], _WrappedCall):
     def __await__(self) -> Generator[Any, None, U]:
         try:

--- a/tests/asyncio/test_grpc_helpers_async.py
+++ b/tests/asyncio/test_grpc_helpers_async.py
@@ -266,6 +266,28 @@ def test_wrap_errors_non_streaming(wrap_unary_errors):
     wrap_unary_errors.assert_called_once_with(callable_)
 
 
+def test_grpc_async_stream():
+    """
+    GrpcAsyncStream type be both an AsyncIterator and a grpc.aio.Call.
+    """
+    instance = grpc_helpers_async.GrpcAsyncStream[int]()
+    assert isinstance(instance, grpc.aio.Call)
+    # should implement __aiter__ and __anext__
+    assert hasattr(instance, "__aiter__")
+    it = instance.__aiter__()
+    assert hasattr(it, "__anext__")
+
+
+def test_awaitable_grpc_call():
+    """
+    AwaitableGrpcCall type should be an Awaitable and a grpc.aio.Call.
+    """
+    instance = grpc_helpers_async.AwaitableGrpcCall[int]()
+    assert isinstance(instance, grpc.aio.Call)
+    # should implement __await__
+    assert hasattr(instance, "__await__")
+
+
 @mock.patch("google.api_core.grpc_helpers_async._wrap_stream_errors")
 def test_wrap_errors_streaming(wrap_stream_errors):
     callable_ = mock.create_autospec(aio.UnaryStreamMultiCallable)

--- a/tests/asyncio/test_grpc_helpers_async.py
+++ b/tests/asyncio/test_grpc_helpers_async.py
@@ -268,7 +268,7 @@ def test_wrap_errors_non_streaming(wrap_unary_errors):
 
 def test_grpc_async_stream():
     """
-    GrpcAsyncStream type be both an AsyncIterator and a grpc.aio.Call.
+    GrpcAsyncStream type should be both an AsyncIterator and a grpc.aio.Call.
     """
     instance = grpc_helpers_async.GrpcAsyncStream[int]()
     assert isinstance(instance, grpc.aio.Call)

--- a/tests/unit/test_grpc_helpers.py
+++ b/tests/unit/test_grpc_helpers.py
@@ -73,14 +73,14 @@ def test_wrap_unary_errors():
     assert exc_info.value.response == grpc_error
 
 
-class Test_StreamingResponseIterator:
+class TestGrpcStream:
     @staticmethod
     def _make_wrapped(*items):
         return iter(items)
 
     @staticmethod
     def _make_one(wrapped, **kw):
-        return grpc_helpers._StreamingResponseIterator(wrapped, **kw)
+        return grpc_helpers.GrpcStream(wrapped, **kw)
 
     def test_ctor_defaults(self):
         wrapped = self._make_wrapped("a", "b", "c")

--- a/tests/unit/test_grpc_helpers.py
+++ b/tests/unit/test_grpc_helpers.py
@@ -73,14 +73,14 @@ def test_wrap_unary_errors():
     assert exc_info.value.response == grpc_error
 
 
-class TestGrpcStream:
+class Test_StreamingResponseIterator:
     @staticmethod
     def _make_wrapped(*items):
         return iter(items)
 
     @staticmethod
     def _make_one(wrapped, **kw):
-        return grpc_helpers.GrpcStream(wrapped, **kw)
+        return grpc_helpers._StreamingResponseIterator(wrapped, **kw)
 
     def test_ctor_defaults(self):
         wrapped = self._make_wrapped("a", "b", "c")

--- a/tests/unit/test_grpc_helpers.py
+++ b/tests/unit/test_grpc_helpers.py
@@ -195,6 +195,24 @@ class Test_StreamingResponseIterator:
         wrapped.trailing_metadata.assert_called_once_with()
 
 
+class TestGrpcStream(Test_StreamingResponseIterator):
+
+    @staticmethod
+    def _make_one(wrapped, **kw):
+        return grpc_helpers.GrpcStream(wrapped, **kw)
+
+    def test_grpc_stream_attributes(self):
+        """
+        Should be both a grpc.Call and an iterable
+        """
+        call = self._make_one(None)
+        assert isinstance(call, grpc.Call)
+        # should implement __iter__
+        assert hasattr(call, "__iter__")
+        it = call.__iter__()
+        assert hasattr(it, "__next__")
+
+
 def test_wrap_stream_okay():
     expected_responses = [1, 2, 3]
     callable_ = mock.Mock(spec=["__call__"], return_value=iter(expected_responses))

--- a/tests/unit/test_grpc_helpers.py
+++ b/tests/unit/test_grpc_helpers.py
@@ -196,7 +196,6 @@ class Test_StreamingResponseIterator:
 
 
 class TestGrpcStream(Test_StreamingResponseIterator):
-
     @staticmethod
     def _make_one(wrapped, **kw):
         return grpc_helpers.GrpcStream(wrapped, **kw)


### PR DESCRIPTION
Our gapic libraries declare that they return `Iterable[SomeProto]` or `Awaitable[SomeProto]` or `Awaitable[AsyncIterable[SomeProto]`, but that doesn't tell the whole story. The objects returned are actually[ `grpc.Call` subclasses](https://github.com/grpc/grpc/blob/0a71e076f8185347be3a27fe8a64cd6c8ecc0d09/src/python/grpcio/grpc/aio/_call.py#L181), which expose the ability to retrieve metadata from the rpc, or call `cancel`, or other trigger useful functionality. 

Unfortunately, there is currently no way to use these `grpc.Call` methods without mypy errors, because of the restrictive return type annotation used

This PR is the first step in addressing this, by giving us a more powerful return type in `api-core`.

On the sync side, I made _StreamingResponseIterator into a Generic container, and gave it a better public facing name. This way, we we can return `GrpcStream[SomeProto]` instead of `Iterable[SomeProto]`, with all grpc.Call methods accessible

On the Async side, I made every `_WrappedXYResponse` class into a Generic container, and declared new `GrpcAsyncStream[SomeProto]` and `AwaitableGrpcCall[SomeProto]` types that can be used in place of `AsyncIterable[SomeProto]` and `Awaitable[SomeProto]` respectively.

For more context on the motivating problem, see https://github.com/googleapis/gapic-generator-python/issues/1856. This PR lays some of the groundwork for resolving that issue in the future. But the type improvements here should also stand alone