### PR TITLE
fix: for backwards compatibility, expose legacy retry imports

### DIFF
--- a/google/api_core/retry/__init__.py
+++ b/google/api_core/retry/__init__.py
@@ -1,5 +1,4 @@
 # Copyright 2017 Google LLC
-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,6 +27,22 @@ from .retry_streaming import StreamingRetry
 from .retry_streaming import retry_target_stream
 from .retry_streaming_async import AsyncStreamingRetry
 from .retry_streaming_async import retry_target_stream as retry_target_stream_async
+
+# The following imports are for backwards compatibility with https://github.com/googleapis/python-api-core/blob/4d7d2edee2c108d43deb151e6e0fdceb56b73275/google/api_core/retry.py
+#
+# TODO: Revert these imports on the next major version release (https://github.com/googleapis/python-api-core/issues/576)
+import datetime
+import functools
+import logging
+import random
+import sys
+import time
+import inspect
+import warnings
+from typing import Any, Callable, TypeVar, TYPE_CHECKING
+from google.api_core import datetime_helpers
+from google.api_core import exceptions
+from google.auth import exceptions as auth_exceptions
 
 __all__ = (
     "exponential_sleep_generator",

--- a/google/api_core/retry/__init__.py
+++ b/google/api_core/retry/__init__.py
@@ -31,15 +31,6 @@ from .retry_streaming_async import retry_target_stream as retry_target_stream_as
 # The following imports are for backwards compatibility with https://github.com/googleapis/python-api-core/blob/4d7d2edee2c108d43deb151e6e0fdceb56b73275/google/api_core/retry.py
 #
 # TODO: Revert these imports on the next major version release (https://github.com/googleapis/python-api-core/issues/576)
-import datetime  # noqa: F401
-import functools  # noqa: F401
-import logging  # noqa: F401
-import random  # noqa: F401
-import sys  # noqa: F401
-import time  # noqa: F401
-import inspect  # noqa: F401
-import warnings  # noqa: F401
-from typing import Any, Callable, TypeVar, TYPE_CHECKING  # noqa: F401
 from google.api_core import datetime_helpers  # noqa: F401
 from google.api_core import exceptions  # noqa: F401
 from google.auth import exceptions as auth_exceptions  # noqa: F401

--- a/google/api_core/retry/__init__.py
+++ b/google/api_core/retry/__init__.py
@@ -31,18 +31,18 @@ from .retry_streaming_async import retry_target_stream as retry_target_stream_as
 # The following imports are for backwards compatibility with https://github.com/googleapis/python-api-core/blob/4d7d2edee2c108d43deb151e6e0fdceb56b73275/google/api_core/retry.py
 #
 # TODO: Revert these imports on the next major version release (https://github.com/googleapis/python-api-core/issues/576)
-import datetime
-import functools
-import logging
-import random
-import sys
-import time
-import inspect
-import warnings
-from typing import Any, Callable, TypeVar, TYPE_CHECKING
-from google.api_core import datetime_helpers
-from google.api_core import exceptions
-from google.auth import exceptions as auth_exceptions
+import datetime  # noqa: F401
+import functools  # noqa: F401
+import logging  # noqa: F401
+import random  # noqa: F401
+import sys  # noqa: F401
+import time  # noqa: F401
+import inspect  # noqa: F401
+import warnings  # noqa: F401
+from typing import Any, Callable, TypeVar, TYPE_CHECKING  # noqa: F401
+from google.api_core import datetime_helpers  # noqa: F401
+from google.api_core import exceptions  # noqa: F401
+from google.auth import exceptions as auth_exceptions  # noqa: F401
 
 __all__ = (
     "exponential_sleep_generator",

--- a/tests/unit/retry/test_retry_imports.py
+++ b/tests/unit/retry/test_retry_imports.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/retry/test_retry_imports.py
+++ b/tests/unit/retry/test_retry_imports.py
@@ -26,12 +26,10 @@ def test_legacy_imports_retry_unary_sync():
     from google.api_core.retry import time  # noqa: F401
     from google.api_core.retry import inspect  # noqa: F401
     from google.api_core.retry import warnings  # noqa: F401
-    from google.api_core.retry import (
-        Any,  # noqa: F401
-        Callable,  # noqa: F401
-        TypeVar,  # noqa: F401
-        TYPE_CHECKING,  # noqa: F401
-    )
+    from google.api_core.retry import Any  # noqa: F401
+    from google.api_core.retry import Callable  # noqa: F401
+    from google.api_core.retry import TypeVar  # noqa: F401
+    from google.api_core.retry import TYPE_CHECKING  # noqa: F401
 
     from google.api_core.retry import datetime_helpers  # noqa: F401
     from google.api_core.retry import exceptions  # noqa: F401

--- a/tests/unit/retry/test_retry_imports.py
+++ b/tests/unit/retry/test_retry_imports.py
@@ -12,27 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 def test_legacy_imports_retry_unary_sync():
     # TODO: Delete this test when when we revert these imports on the
     #       next major version release
     #       (https://github.com/googleapis/python-api-core/issues/576)
 
     from google.api_core.retry import logging
-    from google.api_core.retry import datetime
-    from google.api_core.retry import functools
-    from google.api_core.retry import logging
-    from google.api_core.retry import random
-    from google.api_core.retry import sys
-    from google.api_core.retry import time
-    from google.api_core.retry import inspect
-    from google.api_core.retry import warnings
-    from google.api_core.retry import Any, Callable, TypeVar, TYPE_CHECKING
+    from google.api_core.retry import datetime  # noqa: F401
+    from google.api_core.retry import functools  # noqa: F401
+    from google.api_core.retry import logging  # noqa: F401
+    from google.api_core.retry import random  # noqa: F401
+    from google.api_core.retry import sys  # noqa: F401
+    from google.api_core.retry import time  # noqa: F401
+    from google.api_core.retry import inspect  # noqa: F401
+    from google.api_core.retry import warnings  # noqa: F401
+    from google.api_core.retry import Any, Callable, TypeVar, TYPE_CHECKING  # noqa: F401
 
-    from google.api_core.retry import datetime_helpers
-    from google.api_core.retry import exceptions
-    from google.api_core.retry import auth_exceptions
+    from google.api_core.retry import datetime_helpers  # noqa: F401
+    from google.api_core.retry import exceptions  # noqa: F401
+    from google.api_core.retry import auth_exceptions  # noqa: F401
 
     ### FIXME: How do we test the following, and how do we import it in __init__.py?
     # import google.api_core.retry.requests.exceptions
@@ -43,7 +41,7 @@ def test_legacy_imports_retry_unary_async():
     #       next major version release
     #       (https://github.com/googleapis/python-api-core/issues/576)
 
-    from google.api_core import retry_async
+    from google.api_core import retry_async  # noqa: F401
 
     ### FIXME: each of the following cause errors on the "retry_async" part: module not found
     # import google.api_core.retry_async.functools

--- a/tests/unit/retry/test_retry_imports.py
+++ b/tests/unit/retry/test_retry_imports.py
@@ -1,0 +1,55 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+def test_legacy_imports_retry_unary_sync():
+    # TODO: Delete this test when when we revert these imports on the
+    #       next major version release
+    #       (https://github.com/googleapis/python-api-core/issues/576)
+
+    from google.api_core.retry import logging
+    from google.api_core.retry import datetime
+    from google.api_core.retry import functools
+    from google.api_core.retry import logging
+    from google.api_core.retry import random
+    from google.api_core.retry import sys
+    from google.api_core.retry import time
+    from google.api_core.retry import inspect
+    from google.api_core.retry import warnings
+    from google.api_core.retry import Any, Callable, TypeVar, TYPE_CHECKING
+
+    from google.api_core.retry import datetime_helpers
+    from google.api_core.retry import exceptions
+    from google.api_core.retry import auth_exceptions
+
+    ### FIXME: How do we test the following, and how do we import it in __init__.py?
+    # import google.api_core.retry.requests.exceptions
+
+
+def test_legacy_imports_retry_unary_async():
+    # TODO: Delete this test when when we revert these imports on the
+    #       next major version release
+    #       (https://github.com/googleapis/python-api-core/issues/576)
+
+    from google.api_core import retry_async
+
+    ### FIXME: each of the following cause errors on the "retry_async" part: module not found
+    # import google.api_core.retry_async.functools
+    # from google.api_core.retry_async import functools
+    #
+    ## For the above, I tried the following in api_core/__init__.py
+    ## and none made the above statements pass:
+    #  from google.api_core.retry import retry_unary_async as retry_async
+    #  import google.api_core.retry.retry_unary_async as retry_async

--- a/tests/unit/retry/test_retry_imports.py
+++ b/tests/unit/retry/test_retry_imports.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 def test_legacy_imports_retry_unary_sync():
     # TODO: Delete this test when when we revert these imports on the
     #       next major version release
     #       (https://github.com/googleapis/python-api-core/issues/576)
 
-    from google.api_core.retry import logging
     from google.api_core.retry import datetime  # noqa: F401
     from google.api_core.retry import functools  # noqa: F401
     from google.api_core.retry import logging  # noqa: F401
@@ -26,7 +26,12 @@ def test_legacy_imports_retry_unary_sync():
     from google.api_core.retry import time  # noqa: F401
     from google.api_core.retry import inspect  # noqa: F401
     from google.api_core.retry import warnings  # noqa: F401
-    from google.api_core.retry import Any, Callable, TypeVar, TYPE_CHECKING  # noqa: F401
+    from google.api_core.retry import (
+        Any,  # noqa: F401
+        Callable,  # noqa: F401
+        TypeVar,  # noqa: F401
+        TYPE_CHECKING,  # noqa: F401
+    )
 
     from google.api_core.retry import datetime_helpers  # noqa: F401
     from google.api_core.retry import exceptions  # noqa: F401

--- a/tests/unit/retry/test_retry_imports.py
+++ b/tests/unit/retry/test_retry_imports.py
@@ -21,6 +21,7 @@ def test_legacy_imports_retry_unary_sync():
     from google.api_core.retry import exceptions  # noqa: F401
     from google.api_core.retry import auth_exceptions  # noqa: F401
 
+
 def test_legacy_imports_retry_unary_async():
     # TODO: Delete this test when when we revert these imports on the
     #       next major version release

--- a/tests/unit/retry/test_retry_imports.py
+++ b/tests/unit/retry/test_retry_imports.py
@@ -17,20 +17,6 @@ def test_legacy_imports_retry_unary_sync():
     # TODO: Delete this test when when we revert these imports on the
     #       next major version release
     #       (https://github.com/googleapis/python-api-core/issues/576)
-
-    from google.api_core.retry import datetime  # noqa: F401
-    from google.api_core.retry import functools  # noqa: F401
-    from google.api_core.retry import logging  # noqa: F401
-    from google.api_core.retry import random  # noqa: F401
-    from google.api_core.retry import sys  # noqa: F401
-    from google.api_core.retry import time  # noqa: F401
-    from google.api_core.retry import inspect  # noqa: F401
-    from google.api_core.retry import warnings  # noqa: F401
-    from google.api_core.retry import Any  # noqa: F401
-    from google.api_core.retry import Callable  # noqa: F401
-    from google.api_core.retry import TypeVar  # noqa: F401
-    from google.api_core.retry import TYPE_CHECKING  # noqa: F401
-
     from google.api_core.retry import datetime_helpers  # noqa: F401
     from google.api_core.retry import exceptions  # noqa: F401
     from google.api_core.retry import auth_exceptions  # noqa: F401
@@ -43,14 +29,4 @@ def test_legacy_imports_retry_unary_async():
     # TODO: Delete this test when when we revert these imports on the
     #       next major version release
     #       (https://github.com/googleapis/python-api-core/issues/576)
-
     from google.api_core import retry_async  # noqa: F401
-
-    ### FIXME: each of the following cause errors on the "retry_async" part: module not found
-    # import google.api_core.retry_async.functools
-    # from google.api_core.retry_async import functools
-    #
-    ## For the above, I tried the following in api_core/__init__.py
-    ## and none made the above statements pass:
-    #  from google.api_core.retry import retry_unary_async as retry_async
-    #  import google.api_core.retry.retry_unary_async as retry_async

--- a/tests/unit/retry/test_retry_imports.py
+++ b/tests/unit/retry/test_retry_imports.py
@@ -21,10 +21,6 @@ def test_legacy_imports_retry_unary_sync():
     from google.api_core.retry import exceptions  # noqa: F401
     from google.api_core.retry import auth_exceptions  # noqa: F401
 
-    ### FIXME: How do we test the following, and how do we import it in __init__.py?
-    # import google.api_core.retry.requests.exceptions
-
-
 def test_legacy_imports_retry_unary_async():
     # TODO: Delete this test when when we revert these imports on the
     #       next major version release


### PR DESCRIPTION
Fixes #575

BEGIN_COMMIT_OVERRIDE
chore: for backwards compatibility, expose legacy retry imports in the refactored retry logic
END_COMMIT_OVERRIDE
