### PR TITLE
fix(v1): resolve issue handling protobuf responses in rest streaming

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -110,7 +110,7 @@ def default(session, install_grpc=True):
     pytest_args = [
         "python",
         "-m",
-        "py.test",
+        "pytest",
         *(
             # Helpful for running a single test or testfile.
             session.posargs

--- a/noxfile.py
+++ b/noxfile.py
@@ -217,7 +217,20 @@ def docs(session):
     """Build the docs for this library."""
 
     session.install("-e", ".[grpc]")
-    session.install("sphinx==4.2.0", "alabaster", "recommonmark")
+    session.install(
+        # We need to pin to specific versions of the `sphinxcontrib-*` packages
+        # which still support sphinx 4.x.
+        # See https://github.com/googleapis/sphinx-docfx-yaml/issues/344
+        # and https://github.com/googleapis/sphinx-docfx-yaml/issues/345.
+        "sphinxcontrib-applehelp==1.0.4",
+        "sphinxcontrib-devhelp==1.0.2",
+        "sphinxcontrib-htmlhelp==2.0.1",
+        "sphinxcontrib-qthelp==1.0.3",
+        "sphinxcontrib-serializinghtml==1.1.5",
+        "sphinx==4.5.0",
+        "alabaster",
+        "recommonmark",
+    )
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(
@@ -240,7 +253,18 @@ def docfx(session):
 
     session.install("-e", ".")
     session.install(
-        "sphinx==4.0.1", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml"
+        # We need to pin to specific versions of the `sphinxcontrib-*` packages
+        # which still support sphinx 4.x.
+        # See https://github.com/googleapis/sphinx-docfx-yaml/issues/344
+        # and https://github.com/googleapis/sphinx-docfx-yaml/issues/345.
+        "sphinxcontrib-applehelp==1.0.4",
+        "sphinxcontrib-devhelp==1.0.2",
+        "sphinxcontrib-htmlhelp==2.0.1",
+        "sphinxcontrib-qthelp==1.0.3",
+        "sphinxcontrib-serializinghtml==1.1.5",
+        "gcp-sphinx-docfx-yaml",
+        "alabaster",
+        "recommonmark",
     )
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -61,7 +61,7 @@ def lint(session):
     Returns a failure if the linters find linting errors or sufficiently
     serious code quality issues.
     """
-    session.install("flake8", BLACK_VERSION)
+    session.install("flake8==6.0.0", BLACK_VERSION)
     session.install(".")
     session.run(
         "black",

--- a/noxfile.py
+++ b/noxfile.py
@@ -97,9 +97,7 @@ def default(session, install_grpc=True):
     session.install(
         "dataclasses",
         "mock",
-        # Revert to just "pytest" once
-        # https://github.com/pytest-dev/pytest/issues/10451 is fixed
-        "pytest<7.2.0",
+        "pytest",
         "pytest-cov",
         "pytest-xdist",
     )


### PR DESCRIPTION
The changes in this PR were created using `git cherry-pick bcebc92eca69dae81c5e546d526c92b164a6b3b4`

These commits were also added to resolve issues with presubmits:

https://github.com/googleapis/python-api-core/pull/608/commits/8fb3819c387bf8a31fede1fb3b82e00057e2ffa1
https://github.com/googleapis/python-api-core/pull/608/commits/deae4a0894f9fed3ce7e90255a8808a460bc7a1f
https://github.com/googleapis/python-api-core/pull/608/commits/b4cab0de22d5925ceb64eb148f8e3b3187104f0a
https://github.com/googleapis/python-api-core/pull/608/commits/ba6e647c86a1f1ca8883bf75e32d727df51558a3

---

* fix: resolve issue handling protobuf responses in rest streaming

* raise ValueError if response_message_cls is not a subclass of proto.Message or google.protobuf.message.Message

* remove response_type from pytest.mark.parametrize

* 🦉 Updates from OwlBot post-processor

See https://github.com/googleapis/repo-automation-bots/blob/main/packages/owl-bot/README.md

* add test for ValueError in response_iterator._grab()


