### PR TITLE
fix: call wrap_errors on gRPC callables only

### DIFF
--- a/google/api_core/gapic_v1/method.py
+++ b/google/api_core/gapic_v1/method.py
@@ -21,9 +21,14 @@ compression, pagination, and long-running operations to gRPC methods.
 import enum
 import functools
 
-from google.api_core import grpc_helpers
 from google.api_core.gapic_v1 import client_info
 from google.api_core.timeout import TimeToDeadlineTimeout
+try:
+    import grpc
+    from google.api_core import grpc_helpers
+    _GRPC_WRAP_CLASSES = (grpc.UnaryUnaryMultiCallable, grpc.UnaryStreamMultiCallable, grpc.StreamUnaryMultiCallable, grpc.StreamStreamMultiCallable)
+except ImportError:
+    grpc = None
 
 USE_DEFAULT_METADATA = object()
 
@@ -227,7 +232,11 @@ def wrap_method(
             raise ValueError(
                 "with_call=True is only supported for unary calls."
             ) from exc
-    func = grpc_helpers.wrap_errors(func)
+    
+    #  Ensure that wrap_errors is called on a gRPC callable only
+    if grpc and isinstance(func, _GRPC_WRAP_CLASSES):
+        func = grpc_helpers.wrap_errors(func)
+    
     if client_info is not None:
         user_agent_metadata = [client_info.to_grpc_metadata()]
     else:

--- a/google/api_core/gapic_v1/method.py
+++ b/google/api_core/gapic_v1/method.py
@@ -23,10 +23,17 @@ import functools
 
 from google.api_core.gapic_v1 import client_info
 from google.api_core.timeout import TimeToDeadlineTimeout
+
 try:
     import grpc
     from google.api_core import grpc_helpers
-    _GRPC_WRAP_CLASSES = (grpc.UnaryUnaryMultiCallable, grpc.UnaryStreamMultiCallable, grpc.StreamUnaryMultiCallable, grpc.StreamStreamMultiCallable)
+
+    _GRPC_WRAP_CLASSES = (
+        grpc.UnaryUnaryMultiCallable,
+        grpc.UnaryStreamMultiCallable,
+        grpc.StreamUnaryMultiCallable,
+        grpc.StreamStreamMultiCallable,
+    )
 except ImportError:
     grpc = None
 
@@ -232,11 +239,11 @@ def wrap_method(
             raise ValueError(
                 "with_call=True is only supported for unary calls."
             ) from exc
-    
+
     #  Ensure that wrap_errors is called on a gRPC callable only
     if grpc and isinstance(func, _GRPC_WRAP_CLASSES):
         func = grpc_helpers.wrap_errors(func)
-    
+
     if client_info is not None:
         user_agent_metadata = [client_info.to_grpc_metadata()]
     else:

--- a/google/api_core/gapic_v1/method_async.py
+++ b/google/api_core/gapic_v1/method_async.py
@@ -19,11 +19,17 @@ compression, pagination, and long-running operations to gRPC methods.
 
 import functools
 
-from google.api_core import grpc_helpers_async
 from google.api_core.gapic_v1 import client_info
 from google.api_core.gapic_v1.method import _GapicCallable
 from google.api_core.gapic_v1.method import DEFAULT  # noqa: F401
 from google.api_core.gapic_v1.method import USE_DEFAULT_METADATA  # noqa: F401
+
+try:
+    import grpc
+    from google.api_core import grpc_helpers_async
+    _GRPC_WRAP_CLASSES = (grpc.aio.UnaryUnaryMultiCallable, grpc.aio.UnaryStreamMultiCallable, grpc.aio.StreamUnaryMultiCallable, grpc.aio.StreamStreamMultiCallable)
+except ImportError:
+    grpc = None
 
 
 def wrap_method(
@@ -40,7 +46,10 @@ def wrap_method(
             and ``compression`` arguments and applies the common error mapping,
             retry, timeout, metadata, and compression behavior to the low-level RPC method.
     """
-    func = grpc_helpers_async.wrap_errors(func)
+    
+    #  Ensure that wrap_errors is called on a gRPC callable only
+    if grpc and isinstance(func, _GRPC_WRAP_CLASSES):
+        func = grpc_helpers_async.wrap_errors(func)
 
     metadata = [client_info.to_grpc_metadata()] if client_info is not None else None
 

--- a/google/api_core/gapic_v1/method_async.py
+++ b/google/api_core/gapic_v1/method_async.py
@@ -27,7 +27,13 @@ from google.api_core.gapic_v1.method import USE_DEFAULT_METADATA  # noqa: F401
 try:
     import grpc
     from google.api_core import grpc_helpers_async
-    _GRPC_WRAP_CLASSES = (grpc.aio.UnaryUnaryMultiCallable, grpc.aio.UnaryStreamMultiCallable, grpc.aio.StreamUnaryMultiCallable, grpc.aio.StreamStreamMultiCallable)
+
+    _GRPC_WRAP_CLASSES = (
+        grpc.aio.UnaryUnaryMultiCallable,
+        grpc.aio.UnaryStreamMultiCallable,
+        grpc.aio.StreamUnaryMultiCallable,
+        grpc.aio.StreamStreamMultiCallable,
+    )
 except ImportError:
     grpc = None
 
@@ -46,7 +52,7 @@ def wrap_method(
             and ``compression`` arguments and applies the common error mapping,
             retry, timeout, metadata, and compression behavior to the low-level RPC method.
     """
-    
+
     #  Ensure that wrap_errors is called on a gRPC callable only
     if grpc and isinstance(func, _GRPC_WRAP_CLASSES):
         func = grpc_helpers_async.wrap_errors(func)

--- a/tests/asyncio/gapic/test_method_async.py
+++ b/tests/asyncio/gapic/test_method_async.py
@@ -262,3 +262,14 @@ async def test_wrap_method_with_non_grpc_callable():
     result = await wrapped_method(1, 2, meep="moop")
     assert result == 42
     method.assert_called_once_with(1, 2, meep="moop", metadata=mock.ANY)
+
+
+@pytest.mark.asyncio
+async def test_wrap_method_without_grpc_module():
+    return_value = 42
+    method = mock.Mock(return_value=return_value)
+    with mock.patch("google.api_core.gapic_v1.method_async.grpc", None):
+        wrapped_method =  gapic_v1.method_async.wrap_method(method)
+    result = wrapped_method(1, 2, meep="moop")
+    assert result == 42
+    method.assert_called_once_with(1, 2, meep="moop", metadata=mock.ANY)

--- a/tests/asyncio/gapic/test_method_async.py
+++ b/tests/asyncio/gapic/test_method_async.py
@@ -269,7 +269,7 @@ async def test_wrap_method_without_grpc_module():
     return_value = 42
     method = mock.Mock(return_value=return_value)
     with mock.patch("google.api_core.gapic_v1.method_async.grpc", None):
-        wrapped_method =  gapic_v1.method_async.wrap_method(method)
+        wrapped_method = gapic_v1.method_async.wrap_method(method)
     result = wrapped_method(1, 2, meep="moop")
     assert result == 42
     method.assert_called_once_with(1, 2, meep="moop", metadata=mock.ANY)

--- a/tests/asyncio/gapic/test_method_async.py
+++ b/tests/asyncio/gapic/test_method_async.py
@@ -252,3 +252,13 @@ async def test_wrap_method_with_overriding_timeout_as_a_number():
 
     assert result == 42
     method.assert_called_once_with(timeout=22, metadata=mock.ANY)
+
+
+@pytest.mark.asyncio
+async def test_wrap_method_with_non_grpc_callable():
+    return_value = 42
+    method = mock.AsyncMock(return_value=return_value)
+    wrapped_method = gapic_v1.method_async.wrap_method(method)
+    result = await wrapped_method(1, 2, meep="moop")
+    assert result == 42
+    method.assert_called_once_with(1, 2, meep="moop", metadata=mock.ANY)

--- a/tests/asyncio/gapic/test_method_async.py
+++ b/tests/asyncio/gapic/test_method_async.py
@@ -268,15 +268,17 @@ async def test_wrap_method_with_non_grpc_callable():
 async def test_wrap_method_without_grpc_module():
     return_value = 42
     method = mock.AsyncMock(return_value=return_value)
-    with mock.patch.dict("sys.modules", {"grpc": None, "google.api_core.grpc_helpers_async": None}):
+    with mock.patch.dict(
+        "sys.modules", {"grpc": None, "google.api_core.grpc_helpers_async": None}
+    ):
         import importlib
         import google.api_core.gapic_v1.method_async as method_async
 
         # Reload the module to apply the patch
         importlib.reload(method_async)
-        
-        wrapped_method =  method_async.wrap_method(method)
-       
+
+        wrapped_method = method_async.wrap_method(method)
+
         # Verify that grpc is None
         assert method_async.grpc is None
 

--- a/tests/unit/gapic/test_method.py
+++ b/tests/unit/gapic/test_method.py
@@ -243,3 +243,13 @@ def test_benchmark_gapic_call():
     )
     avg_time = timeit(lambda: gapic_callable(), number=10_000)
     assert avg_time < 0.4
+
+
+@pytest.mark.asyncio
+async def test_wrap_method_with_non_grpc_callable():
+    return_value = 42
+    method = mock.Mock(return_value=return_value)
+    wrapped_method = google.api_core.gapic_v1.method.wrap_method(method)
+    result = wrapped_method(1, 2, meep="moop")
+    assert result == 42
+    method.assert_called_once_with(1, 2, meep="moop", metadata=mock.ANY)

--- a/tests/unit/gapic/test_method.py
+++ b/tests/unit/gapic/test_method.py
@@ -253,3 +253,14 @@ async def test_wrap_method_with_non_grpc_callable():
     result = wrapped_method(1, 2, meep="moop")
     assert result == 42
     method.assert_called_once_with(1, 2, meep="moop", metadata=mock.ANY)
+
+
+@pytest.mark.asyncio
+async def test_wrap_method_without_grpc_module():
+    return_value = 42
+    method = mock.Mock(return_value=return_value)
+    with mock.patch("google.api_core.gapic_v1.method.grpc", None):
+        wrapped_method = google.api_core.gapic_v1.method.wrap_method(method)
+    result = wrapped_method(1, 2, meep="moop")
+    assert result == 42
+    method.assert_called_once_with(1, 2, meep="moop", metadata=mock.ANY)

--- a/tests/unit/gapic/test_method.py
+++ b/tests/unit/gapic/test_method.py
@@ -257,15 +257,17 @@ def test_wrap_method_with_non_grpc_callable():
 def test_wrap_method_without_grpc_module():
     return_value = 42
     method = mock.Mock(return_value=return_value)
-    with mock.patch.dict("sys.modules", {"grpc": None, "google.api_core.grpc_helpers": None}):
+    with mock.patch.dict(
+        "sys.modules", {"grpc": None, "google.api_core.grpc_helpers": None}
+    ):
         import importlib
         import google.api_core.gapic_v1.method as gapic_v1_method
+
         importlib.reload(gapic_v1_method)
 
-        wrapped_method =  gapic_v1_method.wrap_method(method)
+        wrapped_method = gapic_v1_method.wrap_method(method)
         # Reload the module to apply the patch
 
-        
         # Verify that grpc is None
         assert gapic_v1_method.grpc is None
 


### PR DESCRIPTION
Fixes googleapis/google-cloud-python#15053 🦕
