### PR TITLE
chore(revert): Revert "feat: add caching to GapicCallable"

### DIFF
--- a/google/api_core/gapic_v1/method.py
+++ b/google/api_core/gapic_v1/method.py
@@ -42,6 +42,24 @@ DEFAULT = _MethodDefault._DEFAULT_VALUE
 so the default should be used."""
 
 
+def _is_not_none_or_false(value):
+    return value is not None and value is not False
+
+
+def _apply_decorators(func, decorators):
+    """Apply a list of decorators to a given function.
+
+    ``decorators`` may contain items that are ``None`` or ``False`` which will
+    be ignored.
+    """
+    filtered_decorators = filter(_is_not_none_or_false, reversed(decorators))
+
+    for decorator in filtered_decorators:
+        func = decorator(func)
+
+    return func
+
+
 class _GapicCallable(object):
     """Callable that applies retry, timeout, and metadata logic.
 
@@ -73,8 +91,6 @@ class _GapicCallable(object):
     ):
         self._target = target
         self._retry = retry
-        if isinstance(timeout, (int, float)):
-            timeout = TimeToDeadlineTimeout(timeout=timeout)
         self._timeout = timeout
         self._compression = compression
         self._metadata = metadata
@@ -84,42 +100,35 @@ class _GapicCallable(object):
     ):
         """Invoke the low-level RPC with retry, timeout, compression, and metadata."""
 
+        if retry is DEFAULT:
+            retry = self._retry
+
+        if timeout is DEFAULT:
+            timeout = self._timeout
+
         if compression is DEFAULT:
             compression = self._compression
-        if compression is not None:
-            kwargs["compression"] = compression
+
+        if isinstance(timeout, (int, float)):
+            timeout = TimeToDeadlineTimeout(timeout=timeout)
+
+        # Apply all applicable decorators.
+        wrapped_func = _apply_decorators(self._target, [retry, timeout])
 
         # Add the user agent metadata to the call.
         if self._metadata is not None:
-            try:
-                # attempt to concatenate default metadata with user-provided metadata
-                kwargs["metadata"] = (*kwargs["metadata"], *self._metadata)
-            except (KeyError, TypeError):
-                # if metadata is not provided, use just the default metadata
-                kwargs["metadata"] = self._metadata
+            metadata = kwargs.get("metadata", [])
+            # Due to the nature of invocation, None should be treated the same
+            # as not specified.
+            if metadata is None:
+                metadata = []
+            metadata = list(metadata)
+            metadata.extend(self._metadata)
+            kwargs["metadata"] = metadata
+        if self._compression is not None:
+            kwargs["compression"] = compression
 
-        call = self._build_wrapped_call(timeout, retry)
-        return call(*args, **kwargs)
-
-    @functools.lru_cache(maxsize=4)
-    def _build_wrapped_call(self, timeout, retry):
-        """
-        Build a wrapped callable that applies retry, timeout, and metadata logic.
-        """
-        wrapped_func = self._target
-        if timeout is DEFAULT:
-            timeout = self._timeout
-        elif isinstance(timeout, (int, float)):
-            timeout = TimeToDeadlineTimeout(timeout=timeout)
-        if timeout is not None:
-            wrapped_func = timeout(wrapped_func)
-
-        if retry is DEFAULT:
-            retry = self._retry
-        if retry is not None:
-            wrapped_func = retry(wrapped_func)
-
-        return wrapped_func
+        return wrapped_func(*args, **kwargs)
 
 
 def wrap_method(

--- a/tests/unit/gapic/test_method.py
+++ b/tests/unit/gapic/test_method.py
@@ -222,24 +222,3 @@ def test_wrap_method_with_call_not_supported():
     with pytest.raises(ValueError) as exc_info:
         google.api_core.gapic_v1.method.wrap_method(method, with_call=True)
     assert "with_call=True is only supported for unary calls" in str(exc_info.value)
-
-
-def test_benchmark_gapic_call():
-    """
-    Ensure the __call__ method performance does not regress from expectations
-
-    __call__ builds a new wrapped function using passed-in timeout and retry, but
-    subsequent calls are cached
-
-    Note: The threshold has been tuned for the CI workers. Test may flake on
-    slower hardware
-    """
-    from google.api_core.gapic_v1.method import _GapicCallable
-    from google.api_core.retry import Retry
-    from timeit import timeit
-
-    gapic_callable = _GapicCallable(
-        lambda *a, **k: 1, retry=Retry(), timeout=1010, compression=False
-    )
-    avg_time = timeit(lambda: gapic_callable(), number=10_000)
-    assert avg_time < 0.4


### PR DESCRIPTION
Reverts googleapis/python-api-core#527 due to the issue reported in https://github.com/googleapis/python-api-core/issues/660