### PR TITLE
chore: move retry async check to wrap time

### DIFF
--- a/google/api_core/retry/retry_unary.py
+++ b/google/api_core/retry/retry_unary.py
@@ -141,10 +141,7 @@ def retry_target(
 
     for sleep in sleep_generator:
         try:
-            result = target()
-            if inspect.isawaitable(result):
-                warnings.warn(_ASYNC_RETRY_WARNING)
-            return result
+            return target()
 
         # pylint: disable=broad-except
         # This function explicitly must deal with broad exceptions.
@@ -280,6 +277,8 @@ class Retry(_BaseRetry):
             Callable: A callable that will invoke ``func`` with retry
                 behavior.
         """
+        if inspect.iscoroutinefunction(func):
+            warnings.warn(_ASYNC_RETRY_WARNING)
         if self._on_error is not None:
             on_error = self._on_error
 

--- a/tests/unit/retry/test_retry_unary.py
+++ b/tests/unit/retry/test_retry_unary.py
@@ -104,6 +104,7 @@ async def test_retry_target_warning_for_retry(utcnow, sleep):
     """
     retry.Retry should raise warning when wrapping an async function.
     """
+
     async def target():
         pass
 

--- a/tests/unit/retry/test_retry_unary.py
+++ b/tests/unit/retry/test_retry_unary.py
@@ -101,14 +101,19 @@ def test_retry_target_non_retryable_error(utcnow, sleep):
 )
 @pytest.mark.asyncio
 async def test_retry_target_warning_for_retry(utcnow, sleep):
-    predicate = retry.if_exception_type(ValueError)
-    target = mock.AsyncMock(spec=["__call__"])
+    """
+    retry.Retry should raise warning when wrapping an async function.
+    """
+    async def target():
+        pass
+
+    retry_obj = retry.Retry()
 
     with pytest.warns(Warning) as exc_info:
-        # Note: predicate is just a filler and doesn't affect the test
-        retry.retry_target(target, predicate, range(10), None)
+        # raise warning when wrapping an async function
+        retry_obj(target)
 
-    assert len(exc_info) == 2
+    assert len(exc_info) == 1
     assert str(exc_info[0].message) == retry.retry_unary._ASYNC_RETRY_WARNING
     sleep.assert_not_called()
 

--- a/tests/unit/retry/test_retry_unary.py
+++ b/tests/unit/retry/test_retry_unary.py
@@ -106,7 +106,7 @@ async def test_retry_target_warning_for_retry(utcnow, sleep):
     """
 
     async def target():
-        pass
+        pass  # pragma: NO COVER
 
     retry_obj = retry.Retry()
 


### PR DESCRIPTION
Opening a new PR to restore the features in https://github.com/googleapis/python-api-core/pull/649 which were reverted in #667 due to tests failing in cl/640306895

cc @daniel-sanche 
