### PR TITLE
build: use mypy<1.11.0 until #682 is fixed

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -247,7 +247,7 @@ def pytype(session):
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def mypy(session):
     """Run type-checking."""
-    session.install(".[grpc]", "mypy")
+    session.install(".[grpc]", "mypy<1.11.0")
     session.install(
         "types-setuptools",
         "types-requests",

--- a/noxfile.py
+++ b/noxfile.py
@@ -247,6 +247,8 @@ def pytype(session):
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def mypy(session):
     """Run type-checking."""
+    # TODO(https://github.com/googleapis/python-api-core/issues/682):
+    # Use the latest version of mypy instead of mypy<1.11.0
     session.install(".[grpc]", "mypy<1.11.0")
     session.install(
         "types-setuptools",


### PR DESCRIPTION
This will allow us to unblock other development until #682 is fixed.