### PR TITLE
chore: update unittest workflow template

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -47,6 +47,7 @@ jobs:
       with:
         name: coverage-artifact-${{ matrix.option }}-${{ matrix.python }}
         path: .coverage${{ matrix.option }}-${{ matrix.python }}
+        include-hidden-files: true
 
   report-coverage:
     name: cover


### PR DESCRIPTION
This change is adding `include-hidden-files` to the `upload-artifact` step. The `upload-artifact` excludes hidden files by default [here](https://github.com/actions/upload-artifact/commit/50769540e7f4bd5e21e526ee35c689e35e0d6874) so that `.coverage-*` files would be excluded to be uploaded. 

The unit tests coverage is failing in the github workflow.
See related issue: https://github.com/googleapis/synthtool/pull/2008
See related change: https://github.com/googleapis/synthtool/commit/e6f91eb4db419b02af74197905b99fa00a6030c0#diff-0dbf2b78c50a77be560a8578d2ce0ffa60ab27416743f7a4814135f23414588d