### PR TITLE
feat: add async unsupported paramater exception

### DIFF
--- a/google/api_core/exceptions.py
+++ b/google/api_core/exceptions.py
@@ -444,7 +444,6 @@ class DeadlineExceeded(GatewayTimeout):
 
 class AsyncRestUnsupportedParameterError(NotImplementedError):
     """Raised when an unsupported parameter is configured against async rest transport."""
-
     pass
 
 

--- a/google/api_core/exceptions.py
+++ b/google/api_core/exceptions.py
@@ -442,6 +442,12 @@ class DeadlineExceeded(GatewayTimeout):
     grpc_status_code = grpc.StatusCode.DEADLINE_EXCEEDED if grpc is not None else None
 
 
+class AsyncRestUnsupportedParameterError(NotImplementedError):
+    """Raised when an unsupported parameter is configured against async rest transport."""
+
+    pass
+
+
 def exception_class_for_http_status(status_code):
     """Return the exception class for a specific HTTP status code.
 

--- a/google/api_core/exceptions.py
+++ b/google/api_core/exceptions.py
@@ -444,6 +444,7 @@ class DeadlineExceeded(GatewayTimeout):
 
 class AsyncRestUnsupportedParameterError(NotImplementedError):
     """Raised when an unsupported parameter is configured against async rest transport."""
+
     pass
 
 


### PR DESCRIPTION
This PR implements a new exception type i.e. `AsyncRestUnsupportedParameterError` which is raised when an unsupported parameter is configured against the async rest transport.