### PR TITLE
chore: add `async_rest` extra for async rest dependencies

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        option: ["", "_grpc_gcp", "_wo_grpc", "_with_prerelease_deps", "_with_async_rest_extra"]
+        option: ["", "_grpc_gcp", "_wo_grpc", "_w_prerelease_deps", "_w_async_rest_extra"]
         python:
           - "3.7"
           - "3.8"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        option: ["", "_grpc_gcp", "_wo_grpc", "_with_prerelease_deps", "_with_auth_aio"]
+        option: ["", "_grpc_gcp", "_wo_grpc", "_with_prerelease_deps", "_with_async_rest_extra"]
         python:
           - "3.7"
           - "3.8"

--- a/google/api_core/rest_streaming_async.py
+++ b/google/api_core/rest_streaming_async.py
@@ -22,7 +22,9 @@ try:
     import google.auth.aio.transport
 except ImportError as e:  # pragma: NO COVER
     raise ImportError(
-        "google-api-core[async_rest] is required to use asynchronous rest streaming."
+        "`google-api-core[async_rest]` is required to use asynchronous rest streaming. "
+        "Install the `async_rest` extra of `google-api-core` using "
+        "`pip install google-api-core[async_rest]`."
     ) from e
 
 import google.protobuf.message

--- a/google/api_core/rest_streaming_async.py
+++ b/google/api_core/rest_streaming_async.py
@@ -22,7 +22,7 @@ try:
     import google.auth.aio.transport
 except ImportError as e:  # pragma: NO COVER
     raise ImportError(
-        "google-auth>=2.35.0 is required to use asynchronous rest streaming."
+        "google-api-core[async_rest] is required to use asynchronous rest streaming."
     ) from e
 
 import google.protobuf.message

--- a/noxfile.py
+++ b/noxfile.py
@@ -147,9 +147,7 @@ def default(session, install_grpc=True, prerelease=False, install_async_rest=Fal
             f"{constraints_dir}/constraints-{constraints_type}{PYTHON_VERSIONS[0]}.txt",
         )
         # This *must* be the last install command to get the package from source.
-        session.install(
-            "-e", f".[{','.join(install_extras)}]", "--no-deps"
-        )
+        session.install("-e", f".[{','.join(install_extras)}]", "--no-deps")
     else:
         constraints_file = (
             f"{constraints_dir}/constraints-{constraints_type}{session.python}.txt"

--- a/noxfile.py
+++ b/noxfile.py
@@ -38,7 +38,7 @@ nox.options.sessions = [
     "unit",
     "unit_grpc_gcp",
     "unit_wo_grpc",
-    "unit_with_auth_aio",
+    "unit_with_async_rest_extra",
     "cover",
     "pytype",
     "mypy",
@@ -110,7 +110,7 @@ def install_prerelease_dependencies(session, constraints_path):
         session.install(*other_deps)
 
 
-def default(session, install_grpc=True, prerelease=False, install_auth_aio=False):
+def default(session, install_grpc=True, prerelease=False, install_async_rest=False):
     """Default unit test session.
 
     This is intended to be run **without** an interpreter set, so
@@ -130,24 +130,40 @@ def default(session, install_grpc=True, prerelease=False, install_auth_aio=False
     )
 
     constraints_dir = str(CURRENT_DIRECTORY / "testing")
-
+    constraints_type = "async-rest-" if install_async_rest else ""
     if prerelease:
         install_prerelease_dependencies(
-            session, f"{constraints_dir}/constraints-{PYTHON_VERSIONS[0]}.txt"
+            session,
+            f"{constraints_dir}/constraints-{constraints_type}{PYTHON_VERSIONS[0]}.txt",
         )
         # This *must* be the last install command to get the package from source.
-        session.install("-e", ".", "--no-deps")
+        session.install(
+            "-e", "." + ("[async_rest]" if install_async_rest else ""), "--no-deps"
+        )
     else:
+        constraints_file = (
+            f"{constraints_dir}/constraints-{constraints_type}{session.python}.txt"
+        )
+        # fall back to standard constraints file
+        if not pathlib.Path(constraints_file).exists():
+            constraints_file = f"{constraints_dir}/constraints-{session.python}.txt"
+
         session.install(
             "-e",
-            ".[grpc]" if install_grpc else ".",
+            "."
+            + (
+                "[grpc,async_rest]"
+                if install_grpc and install_async_rest
+                else (
+                    "[grpc]"
+                    if install_grpc
+                    else "[async_rest]"
+                    if install_async_rest
+                    else ""
+                )
+            ),
             "-c",
-            f"{constraints_dir}/constraints-{session.python}.txt",
-        )
-
-    if install_auth_aio:
-        session.install(
-            "google-auth @ git+https://git@github.com/googleapis/google-auth-library-python@8833ad6f92c3300d6645355994c7db2356bd30ad"
+            constraints_file,
         )
 
     # Print out package versions of dependencies
@@ -236,9 +252,9 @@ def unit_wo_grpc(session):
 
 
 @nox.session(python=PYTHON_VERSIONS)
-def unit_with_auth_aio(session):
-    """Run the unit test suite with google.auth.aio installed"""
-    default(session, install_auth_aio=True)
+def unit_with_async_rest_extra(session):
+    """Run the unit test suite with the `async_rest` extra"""
+    default(session, install_async_rest=True)
 
 
 @nox.session(python=DEFAULT_PYTHON_VERSION)
@@ -261,7 +277,7 @@ def mypy(session):
     """Run type-checking."""
     # TODO(https://github.com/googleapis/python-api-core/issues/682):
     # Use the latest version of mypy instead of mypy<1.11.0
-    session.install(".[grpc]", "mypy<1.11.0")
+    session.install(".[grpc,async_rest]", "mypy<1.11.0")
     session.install(
         "types-setuptools",
         "types-requests",

--- a/noxfile.py
+++ b/noxfile.py
@@ -141,13 +141,14 @@ def default(session, install_grpc=True, prerelease=False, install_async_rest=Fal
     else:
         constraints_type = ""
 
+    lib_with_extras = f".[{','.join(install_extras)}]" if len(install_extras) else "."
     if prerelease:
         install_prerelease_dependencies(
             session,
             f"{constraints_dir}/constraints-{constraints_type}{PYTHON_VERSIONS[0]}.txt",
         )
         # This *must* be the last install command to get the package from source.
-        session.install("-e", f".[{','.join(install_extras)}]", "--no-deps")
+        session.install("-e", lib_with_extras, "--no-deps")
     else:
         constraints_file = (
             f"{constraints_dir}/constraints-{constraints_type}{session.python}.txt"
@@ -158,7 +159,7 @@ def default(session, install_grpc=True, prerelease=False, install_async_rest=Fal
 
         session.install(
             "-e",
-            f".[{','.join(install_extras)}]",
+            lib_with_extras,
             "-c",
             constraints_file,
         )

--- a/noxfile.py
+++ b/noxfile.py
@@ -38,7 +38,8 @@ nox.options.sessions = [
     "unit",
     "unit_grpc_gcp",
     "unit_wo_grpc",
-    "unit_with_async_rest_extra",
+    "unit_w_prerelease_deps",
+    "unit_w_async_rest_extra",
     "cover",
     "pytype",
     "mypy",
@@ -221,7 +222,7 @@ def unit(session):
 
 
 @nox.session(python=PYTHON_VERSIONS)
-def unit_with_prerelease_deps(session):
+def unit_w_prerelease_deps(session):
     """Run the unit test suite."""
     default(session, prerelease=True)
 
@@ -252,7 +253,7 @@ def unit_wo_grpc(session):
 
 
 @nox.session(python=PYTHON_VERSIONS)
-def unit_with_async_rest_extra(session):
+def unit_w_async_rest_extra(session):
     """Run the unit test suite with the `async_rest` extra"""
     default(session, install_async_rest=True)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -130,8 +130,17 @@ def default(session, install_grpc=True, prerelease=False, install_async_rest=Fal
         "pytest-xdist",
     )
 
+    install_extras = []
+    if install_grpc:
+        install_extras.append("grpc")
+
     constraints_dir = str(CURRENT_DIRECTORY / "testing")
-    constraints_type = "async-rest-" if install_async_rest else ""
+    if install_async_rest:
+        install_extras.append("async_rest")
+        constraints_type = "async-rest-"
+    else:
+        constraints_type = ""
+
     if prerelease:
         install_prerelease_dependencies(
             session,
@@ -139,7 +148,7 @@ def default(session, install_grpc=True, prerelease=False, install_async_rest=Fal
         )
         # This *must* be the last install command to get the package from source.
         session.install(
-            "-e", "." + ("[async_rest]" if install_async_rest else ""), "--no-deps"
+            "-e", f".[{','.join(install_extras)}]", "--no-deps"
         )
     else:
         constraints_file = (
@@ -151,18 +160,7 @@ def default(session, install_grpc=True, prerelease=False, install_async_rest=Fal
 
         session.install(
             "-e",
-            "."
-            + (
-                "[grpc,async_rest]"
-                if install_grpc and install_async_rest
-                else (
-                    "[grpc]"
-                    if install_grpc
-                    else "[async_rest]"
-                    if install_async_rest
-                    else ""
-                )
-            ),
+            f".[{','.join(install_extras)}]",
             "-c",
             constraints_file,
         )

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,9 @@ dependencies = [
     "requests >= 2.18.0, < 3.0.0.dev0",
 ]
 extras = {
+    "async_rest": [
+        "google-auth[aiohttp] >= 2.35.0, < 3.0.dev0",
+    ],
     "grpc": [
         "grpcio >= 1.33.2, < 2.0dev",
         "grpcio >= 1.49.1, < 2.0dev; python_version>='3.11'",

--- a/testing/constraints-async-rest-3.7.txt
+++ b/testing/constraints-async-rest-3.7.txt
@@ -7,8 +7,10 @@
 # Then this file should have foo==1.14.0
 googleapis-common-protos==1.56.2
 protobuf==3.19.5
-google-auth==2.14.1
-requests==2.18.0
+google-auth==2.35.0
+# from google-auth[aiohttp]
+aiohttp==3.6.2
+requests==2.20.0
 grpcio==1.33.2
 grpcio-status==1.33.2
 grpcio-gcp==0.2.2

--- a/tests/asyncio/test_rest_streaming_async.py
+++ b/tests/asyncio/test_rest_streaming_async.py
@@ -35,7 +35,7 @@ except ImportError:
 
 if not AUTH_AIO_INSTALLED:  # pragma: NO COVER
     pytest.skip(
-        "google-auth>=2.35.0 is required to use asynchronous rest streaming.",
+        "google-api-core[async_rest] is required to use asynchronous rest streaming.",
         allow_module_level=True,
     )
 

--- a/tests/asyncio/test_rest_streaming_async.py
+++ b/tests/asyncio/test_rest_streaming_async.py
@@ -28,14 +28,9 @@ import proto
 
 try:
     from google.auth.aio.transport import Response
-
-    AUTH_AIO_INSTALLED = True
 except ImportError:
-    AUTH_AIO_INSTALLED = False
-
-if not AUTH_AIO_INSTALLED:  # pragma: NO COVER
     pytest.skip(
-        "google-api-core[async_rest] is required to use asynchronous rest streaming.",
+        "google-api-core[async_rest] is required to test asynchronous rest streaming.",
         allow_module_level=True,
     )
 


### PR DESCRIPTION
This PR adds an extra for `async_rest` which captures the minimum version of `google-auth` which is required to use the `async_rest` feature.