### PR TITLE
fix: Switch to unittest.mock from mock

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -124,6 +124,7 @@ def default(session, install_grpc=True, prerelease=False, install_async_rest=Fal
 
     session.install(
         "dataclasses",
+        "mock; python_version=='3.7'",
         "pytest",
         "pytest-cov",
         "pytest-xdist",
@@ -280,6 +281,7 @@ def mypy(session):
         "types-requests",
         "types-protobuf",
         "types-dataclasses",
+        "types-mock; python_version=='3.7'",
     )
     session.run("mypy", "google", "tests")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -124,7 +124,6 @@ def default(session, install_grpc=True, prerelease=False, install_async_rest=Fal
 
     session.install(
         "dataclasses",
-        "mock",
         "pytest",
         "pytest-cov",
         "pytest-xdist",
@@ -280,7 +279,6 @@ def mypy(session):
         "types-setuptools",
         "types-requests",
         "types-protobuf",
-        "types-mock",
         "types-dataclasses",
     )
     session.run("mypy", "google", "tests")

--- a/tests/asyncio/future/test_async_future.py
+++ b/tests/asyncio/future/test_async_future.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import asyncio
+from unittest import mock
 
-import mock
 import pytest
 
 from google.api_core import exceptions

--- a/tests/asyncio/gapic/test_method_async.py
+++ b/tests/asyncio/gapic/test_method_async.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import datetime
+
 try:
     from unittest import mock
-    from unittest.mock import AsyncMock  # pragma: NO COVER
+    from unittest.mock import AsyncMock  # pragma: NO COVER  # noqa: F401
 except ImportError:  # pragma: NO COVER
     import mock  # type: ignore
 import pytest

--- a/tests/asyncio/gapic/test_method_async.py
+++ b/tests/asyncio/gapic/test_method_async.py
@@ -15,6 +15,10 @@
 import datetime
 from unittest import mock
 
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    from mock import AsyncMock
 import pytest
 
 try:
@@ -256,7 +260,7 @@ async def test_wrap_method_with_overriding_timeout_as_a_number():
 
 @pytest.mark.asyncio
 async def test_wrap_method_without_wrap_errors():
-    fake_call = mock.AsyncMock()
+    fake_call = AsyncMock()
 
     wrapped_method = gapic_v1.method_async.wrap_method(fake_call, kind="rest")
     with mock.patch("google.api_core.grpc_helpers_async.wrap_errors") as method:

--- a/tests/asyncio/gapic/test_method_async.py
+++ b/tests/asyncio/gapic/test_method_async.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 import datetime
-from unittest import mock
-
 try:
-    from unittest.mock import AsyncMock
-except ImportError:
-    from mock import AsyncMock
+    from unittest import mock
+    from unittest.mock import AsyncMock  # pragma: NO COVER
+except ImportError:  # pragma: NO COVER
+    import mock  # type: ignore
 import pytest
 
 try:
@@ -260,7 +259,7 @@ async def test_wrap_method_with_overriding_timeout_as_a_number():
 
 @pytest.mark.asyncio
 async def test_wrap_method_without_wrap_errors():
-    fake_call = AsyncMock()
+    fake_call = mock.AsyncMock()
 
     wrapped_method = gapic_v1.method_async.wrap_method(fake_call, kind="rest")
     with mock.patch("google.api_core.grpc_helpers_async.wrap_errors") as method:

--- a/tests/asyncio/gapic/test_method_async.py
+++ b/tests/asyncio/gapic/test_method_async.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import datetime
+from unittest import mock
 
-import mock
 import pytest
 
 try:

--- a/tests/asyncio/operations_v1/test_operations_async_client.py
+++ b/tests/asyncio/operations_v1/test_operations_async_client.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
+
 import pytest
 
 try:

--- a/tests/asyncio/retry/test_retry_streaming_async.py
+++ b/tests/asyncio/retry/test_retry_streaming_async.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import datetime
 import re
-import asyncio
+from unittest import mock
 
-import mock
 import pytest
 
 from google.api_core import exceptions

--- a/tests/asyncio/retry/test_retry_streaming_async.py
+++ b/tests/asyncio/retry/test_retry_streaming_async.py
@@ -15,7 +15,12 @@
 import asyncio
 import datetime
 import re
-from unittest import mock
+
+try:
+    from unittest import mock
+    from unittest.mock import AsyncMock  # pragma: NO COVER  # noqa: F401
+except ImportError:  # pragma: NO COVER
+    import mock  # type: ignore
 
 import pytest
 

--- a/tests/asyncio/retry/test_retry_unary_async.py
+++ b/tests/asyncio/retry/test_retry_unary_async.py
@@ -16,6 +16,10 @@ import datetime
 import re
 from unittest import mock
 
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    from mock import AsyncMock
 import pytest
 
 from google.api_core import exceptions
@@ -168,7 +172,7 @@ class TestAsyncRetry(Test_BaseRetry):
     @pytest.mark.asyncio
     async def test___call___and_execute_success(self, sleep):
         retry_ = retry_async.AsyncRetry()
-        target = mock.AsyncMock(spec=["__call__"], return_value=42)
+        target = AsyncMock(spec=["__call__"], return_value=42)
         # __name__ is needed by functools.partial.
         target.__name__ = "target"
 
@@ -190,7 +194,7 @@ class TestAsyncRetry(Test_BaseRetry):
             predicate=retry_async.if_exception_type(ValueError)
         )
 
-        target = mock.AsyncMock(spec=["__call__"], side_effect=[ValueError(), 42])
+        target = AsyncMock(spec=["__call__"], side_effect=[ValueError(), 42])
         # __name__ is needed by functools.partial.
         target.__name__ = "target"
 
@@ -220,7 +224,7 @@ class TestAsyncRetry(Test_BaseRetry):
 
         monotonic_patcher = mock.patch("time.monotonic", return_value=0)
 
-        target = mock.AsyncMock(spec=["__call__"], side_effect=[ValueError()] * 10)
+        target = AsyncMock(spec=["__call__"], side_effect=[ValueError()] * 10)
         # __name__ is needed by functools.partial.
         target.__name__ = "target"
 
@@ -270,7 +274,7 @@ class TestAsyncRetry(Test_BaseRetry):
         # check the proper creation of the class
         assert retry_._on_error is _some_function
 
-        target = mock.AsyncMock(spec=["__call__"], side_effect=[42])
+        target = AsyncMock(spec=["__call__"], side_effect=[42])
         # __name__ is needed by functools.partial.
         target.__name__ = "target"
 
@@ -295,7 +299,7 @@ class TestAsyncRetry(Test_BaseRetry):
         # check the proper creation of the class
         assert retry_._on_error is _some_function
 
-        target = mock.AsyncMock(
+        target = AsyncMock(
             spec=["__call__"], side_effect=[ValueError(), ValueError(), 42]
         )
         # __name__ is needed by functools.partial.

--- a/tests/asyncio/retry/test_retry_unary_async.py
+++ b/tests/asyncio/retry/test_retry_unary_async.py
@@ -14,12 +14,11 @@
 
 import datetime
 import re
-from unittest import mock
-
 try:
-    from unittest.mock import AsyncMock
-except ImportError:
-    from mock import AsyncMock
+    from unittest import mock
+    from unittest.mock import AsyncMock  # pragma: NO COVER
+except ImportError:  # pragma: NO COVER
+    import mock  # type: ignore
 import pytest
 
 from google.api_core import exceptions
@@ -172,7 +171,7 @@ class TestAsyncRetry(Test_BaseRetry):
     @pytest.mark.asyncio
     async def test___call___and_execute_success(self, sleep):
         retry_ = retry_async.AsyncRetry()
-        target = AsyncMock(spec=["__call__"], return_value=42)
+        target = mock.AsyncMock(spec=["__call__"], return_value=42)
         # __name__ is needed by functools.partial.
         target.__name__ = "target"
 
@@ -194,7 +193,7 @@ class TestAsyncRetry(Test_BaseRetry):
             predicate=retry_async.if_exception_type(ValueError)
         )
 
-        target = AsyncMock(spec=["__call__"], side_effect=[ValueError(), 42])
+        target = mock.AsyncMock(spec=["__call__"], side_effect=[ValueError(), 42])
         # __name__ is needed by functools.partial.
         target.__name__ = "target"
 
@@ -224,7 +223,7 @@ class TestAsyncRetry(Test_BaseRetry):
 
         monotonic_patcher = mock.patch("time.monotonic", return_value=0)
 
-        target = AsyncMock(spec=["__call__"], side_effect=[ValueError()] * 10)
+        target = mock.AsyncMock(spec=["__call__"], side_effect=[ValueError()] * 10)
         # __name__ is needed by functools.partial.
         target.__name__ = "target"
 
@@ -274,7 +273,7 @@ class TestAsyncRetry(Test_BaseRetry):
         # check the proper creation of the class
         assert retry_._on_error is _some_function
 
-        target = AsyncMock(spec=["__call__"], side_effect=[42])
+        target = mock.AsyncMock(spec=["__call__"], side_effect=[42])
         # __name__ is needed by functools.partial.
         target.__name__ = "target"
 
@@ -299,7 +298,7 @@ class TestAsyncRetry(Test_BaseRetry):
         # check the proper creation of the class
         assert retry_._on_error is _some_function
 
-        target = AsyncMock(
+        target = mock.AsyncMock(
             spec=["__call__"], side_effect=[ValueError(), ValueError(), 42]
         )
         # __name__ is needed by functools.partial.

--- a/tests/asyncio/retry/test_retry_unary_async.py
+++ b/tests/asyncio/retry/test_retry_unary_async.py
@@ -14,9 +14,10 @@
 
 import datetime
 import re
+
 try:
     from unittest import mock
-    from unittest.mock import AsyncMock  # pragma: NO COVER
+    from unittest.mock import AsyncMock  # pragma: NO COVER  # noqa: F401
 except ImportError:  # pragma: NO COVER
     import mock  # type: ignore
 import pytest

--- a/tests/asyncio/retry/test_retry_unary_async.py
+++ b/tests/asyncio/retry/test_retry_unary_async.py
@@ -14,8 +14,8 @@
 
 import datetime
 import re
+from unittest import mock
 
-import mock
 import pytest
 
 from google.api_core import exceptions

--- a/tests/asyncio/test_grpc_helpers_async.py
+++ b/tests/asyncio/test_grpc_helpers_async.py
@@ -213,9 +213,7 @@ async def test_wrap_stream_errors_aiter():
 
     mock_call = mock.Mock(aio.StreamStreamCall, autospec=True)
     mocked_aiter = mock.Mock(spec=["__anext__"])
-    mocked_aiter.__anext__ = AsyncMock(
-        side_effect=[mock.sentinel.response, grpc_error]
-    )
+    mocked_aiter.__anext__ = AsyncMock(side_effect=[mock.sentinel.response, grpc_error])
     mock_call.__aiter__ = mock.Mock(return_value=mocked_aiter)
     multicallable = mock.Mock(return_value=mock_call)
 

--- a/tests/asyncio/test_grpc_helpers_async.py
+++ b/tests/asyncio/test_grpc_helpers_async.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
+
 import pytest  # noqa: I202
 
 try:

--- a/tests/asyncio/test_grpc_helpers_async.py
+++ b/tests/asyncio/test_grpc_helpers_async.py
@@ -14,7 +14,7 @@
 
 try:
     from unittest import mock
-    from unittest.mock import AsyncMock  # pragma: NO COVER
+    from unittest.mock import AsyncMock  # pragma: NO COVER  # noqa: F401
 except ImportError:  # pragma: NO COVER
     import mock  # type: ignore
 import pytest  # noqa: I202
@@ -212,7 +212,9 @@ async def test_wrap_stream_errors_aiter():
 
     mock_call = mock.Mock(aio.StreamStreamCall, autospec=True)
     mocked_aiter = mock.Mock(spec=["__anext__"])
-    mocked_aiter.__anext__ = mock.AsyncMock(side_effect=[mock.sentinel.response, grpc_error])
+    mocked_aiter.__anext__ = mock.AsyncMock(
+        side_effect=[mock.sentinel.response, grpc_error]
+    )
     mock_call.__aiter__ = mock.Mock(return_value=mocked_aiter)
     multicallable = mock.Mock(return_value=mock_call)
 

--- a/tests/asyncio/test_grpc_helpers_async.py
+++ b/tests/asyncio/test_grpc_helpers_async.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest import mock
-
 try:
-    from unittest.mock import AsyncMock
-except ImportError:
-    from mock import AsyncMock
+    from unittest import mock
+    from unittest.mock import AsyncMock  # pragma: NO COVER
+except ImportError:  # pragma: NO COVER
+    import mock  # type: ignore
 import pytest  # noqa: I202
 
 try:
@@ -54,7 +53,7 @@ class RpcErrorImpl(grpc.RpcError, grpc.Call):
 @pytest.mark.asyncio
 async def test_wrap_unary_errors():
     grpc_error = RpcErrorImpl(grpc.StatusCode.INVALID_ARGUMENT)
-    callable_ = AsyncMock(spec=["__call__"], side_effect=grpc_error)
+    callable_ = mock.AsyncMock(spec=["__call__"], side_effect=grpc_error)
 
     wrapped_callable = grpc_helpers_async._wrap_unary_errors(callable_)
 
@@ -174,7 +173,7 @@ async def test_wrap_stream_errors_stream_stream():
 async def test_wrap_stream_errors_raised():
     grpc_error = RpcErrorImpl(grpc.StatusCode.INVALID_ARGUMENT)
     mock_call = mock.Mock(aio.StreamStreamCall, autospec=True)
-    mock_call.wait_for_connection = AsyncMock(side_effect=[grpc_error])
+    mock_call.wait_for_connection = mock.AsyncMock(side_effect=[grpc_error])
     multicallable = mock.Mock(return_value=mock_call)
 
     wrapped_callable = grpc_helpers_async._wrap_stream_errors(
@@ -191,7 +190,7 @@ async def test_wrap_stream_errors_read():
     grpc_error = RpcErrorImpl(grpc.StatusCode.INVALID_ARGUMENT)
 
     mock_call = mock.Mock(aio.StreamStreamCall, autospec=True)
-    mock_call.read = AsyncMock(side_effect=grpc_error)
+    mock_call.read = mock.AsyncMock(side_effect=grpc_error)
     multicallable = mock.Mock(return_value=mock_call)
 
     wrapped_callable = grpc_helpers_async._wrap_stream_errors(
@@ -213,7 +212,7 @@ async def test_wrap_stream_errors_aiter():
 
     mock_call = mock.Mock(aio.StreamStreamCall, autospec=True)
     mocked_aiter = mock.Mock(spec=["__anext__"])
-    mocked_aiter.__anext__ = AsyncMock(side_effect=[mock.sentinel.response, grpc_error])
+    mocked_aiter.__anext__ = mock.AsyncMock(side_effect=[mock.sentinel.response, grpc_error])
     mock_call.__aiter__ = mock.Mock(return_value=mocked_aiter)
     multicallable = mock.Mock(return_value=mock_call)
 
@@ -234,7 +233,7 @@ async def test_wrap_stream_errors_aiter_non_rpc_error():
 
     mock_call = mock.Mock(aio.StreamStreamCall, autospec=True)
     mocked_aiter = mock.Mock(spec=["__anext__"])
-    mocked_aiter.__anext__ = AsyncMock(
+    mocked_aiter.__anext__ = mock.AsyncMock(
         side_effect=[mock.sentinel.response, non_grpc_error]
     )
     mock_call.__aiter__ = mock.Mock(return_value=mocked_aiter)
@@ -269,8 +268,8 @@ async def test_wrap_stream_errors_write():
     grpc_error = RpcErrorImpl(grpc.StatusCode.INVALID_ARGUMENT)
 
     mock_call = mock.Mock(aio.StreamStreamCall, autospec=True)
-    mock_call.write = AsyncMock(side_effect=[None, grpc_error])
-    mock_call.done_writing = AsyncMock(side_effect=[None, grpc_error])
+    mock_call.write = mock.AsyncMock(side_effect=[None, grpc_error])
+    mock_call.done_writing = mock.AsyncMock(side_effect=[None, grpc_error])
     multicallable = mock.Mock(return_value=mock_call)
 
     wrapped_callable = grpc_helpers_async._wrap_stream_errors(

--- a/tests/asyncio/test_grpc_helpers_async.py
+++ b/tests/asyncio/test_grpc_helpers_async.py
@@ -14,6 +14,10 @@
 
 from unittest import mock
 
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    from mock import AsyncMock
 import pytest  # noqa: I202
 
 try:
@@ -50,7 +54,7 @@ class RpcErrorImpl(grpc.RpcError, grpc.Call):
 @pytest.mark.asyncio
 async def test_wrap_unary_errors():
     grpc_error = RpcErrorImpl(grpc.StatusCode.INVALID_ARGUMENT)
-    callable_ = mock.AsyncMock(spec=["__call__"], side_effect=grpc_error)
+    callable_ = AsyncMock(spec=["__call__"], side_effect=grpc_error)
 
     wrapped_callable = grpc_helpers_async._wrap_unary_errors(callable_)
 
@@ -170,7 +174,7 @@ async def test_wrap_stream_errors_stream_stream():
 async def test_wrap_stream_errors_raised():
     grpc_error = RpcErrorImpl(grpc.StatusCode.INVALID_ARGUMENT)
     mock_call = mock.Mock(aio.StreamStreamCall, autospec=True)
-    mock_call.wait_for_connection = mock.AsyncMock(side_effect=[grpc_error])
+    mock_call.wait_for_connection = AsyncMock(side_effect=[grpc_error])
     multicallable = mock.Mock(return_value=mock_call)
 
     wrapped_callable = grpc_helpers_async._wrap_stream_errors(
@@ -187,7 +191,7 @@ async def test_wrap_stream_errors_read():
     grpc_error = RpcErrorImpl(grpc.StatusCode.INVALID_ARGUMENT)
 
     mock_call = mock.Mock(aio.StreamStreamCall, autospec=True)
-    mock_call.read = mock.AsyncMock(side_effect=grpc_error)
+    mock_call.read = AsyncMock(side_effect=grpc_error)
     multicallable = mock.Mock(return_value=mock_call)
 
     wrapped_callable = grpc_helpers_async._wrap_stream_errors(
@@ -209,7 +213,7 @@ async def test_wrap_stream_errors_aiter():
 
     mock_call = mock.Mock(aio.StreamStreamCall, autospec=True)
     mocked_aiter = mock.Mock(spec=["__anext__"])
-    mocked_aiter.__anext__ = mock.AsyncMock(
+    mocked_aiter.__anext__ = AsyncMock(
         side_effect=[mock.sentinel.response, grpc_error]
     )
     mock_call.__aiter__ = mock.Mock(return_value=mocked_aiter)
@@ -232,7 +236,7 @@ async def test_wrap_stream_errors_aiter_non_rpc_error():
 
     mock_call = mock.Mock(aio.StreamStreamCall, autospec=True)
     mocked_aiter = mock.Mock(spec=["__anext__"])
-    mocked_aiter.__anext__ = mock.AsyncMock(
+    mocked_aiter.__anext__ = AsyncMock(
         side_effect=[mock.sentinel.response, non_grpc_error]
     )
     mock_call.__aiter__ = mock.Mock(return_value=mocked_aiter)
@@ -267,8 +271,8 @@ async def test_wrap_stream_errors_write():
     grpc_error = RpcErrorImpl(grpc.StatusCode.INVALID_ARGUMENT)
 
     mock_call = mock.Mock(aio.StreamStreamCall, autospec=True)
-    mock_call.write = mock.AsyncMock(side_effect=[None, grpc_error])
-    mock_call.done_writing = mock.AsyncMock(side_effect=[None, grpc_error])
+    mock_call.write = AsyncMock(side_effect=[None, grpc_error])
+    mock_call.done_writing = AsyncMock(side_effect=[None, grpc_error])
     multicallable = mock.Mock(return_value=mock_call)
 
     wrapped_callable = grpc_helpers_async._wrap_stream_errors(

--- a/tests/asyncio/test_operation_async.py
+++ b/tests/asyncio/test_operation_async.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 
-import mock
+from unittest import mock
+
 import pytest
 
 try:

--- a/tests/asyncio/test_operation_async.py
+++ b/tests/asyncio/test_operation_async.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 
-from unittest import mock
-
-try:
-    from unittest.mock import AsyncMock
-except ImportError:
-    from mock import AsyncMock
 import pytest
+try:
+    from unittest import mock
+    from unittest.mock import AsyncMock  # pragma: NO COVER
+except ImportError:  # pragma: NO COVER
+    import mock  # type: ignore
 
 try:
     import grpc  # noqa: F401
@@ -59,9 +58,9 @@ def make_operation_future(client_operations_responses=None):
     if client_operations_responses is None:
         client_operations_responses = [make_operation_proto()]
 
-    refresh = AsyncMock(spec=["__call__"], side_effect=client_operations_responses)
+    refresh = mock.AsyncMock(spec=["__call__"], side_effect=client_operations_responses)
     refresh.responses = client_operations_responses
-    cancel = AsyncMock(spec=["__call__"])
+    cancel = mock.AsyncMock(spec=["__call__"])
     operation_future = operation_async.AsyncOperation(
         client_operations_responses[0],
         refresh,

--- a/tests/asyncio/test_operation_async.py
+++ b/tests/asyncio/test_operation_async.py
@@ -15,6 +15,10 @@
 
 from unittest import mock
 
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    from mock import AsyncMock
 import pytest
 
 try:
@@ -55,9 +59,9 @@ def make_operation_future(client_operations_responses=None):
     if client_operations_responses is None:
         client_operations_responses = [make_operation_proto()]
 
-    refresh = mock.AsyncMock(spec=["__call__"], side_effect=client_operations_responses)
+    refresh = AsyncMock(spec=["__call__"], side_effect=client_operations_responses)
     refresh.responses = client_operations_responses
-    cancel = mock.AsyncMock(spec=["__call__"])
+    cancel = AsyncMock(spec=["__call__"])
     operation_future = operation_async.AsyncOperation(
         client_operations_responses[0],
         refresh,

--- a/tests/asyncio/test_operation_async.py
+++ b/tests/asyncio/test_operation_async.py
@@ -14,9 +14,10 @@
 
 
 import pytest
+
 try:
     from unittest import mock
-    from unittest.mock import AsyncMock  # pragma: NO COVER
+    from unittest.mock import AsyncMock  # pragma: NO COVER  # noqa: F401
 except ImportError:  # pragma: NO COVER
     import mock  # type: ignore
 

--- a/tests/asyncio/test_page_iterator_async.py
+++ b/tests/asyncio/test_page_iterator_async.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 import inspect
-from unittest import mock
-
 try:
-    from unittest.mock import AsyncMock
-except ImportError:
-    from mock import AsyncMock
+    from unittest import mock
+    from unittest.mock import AsyncMock  # pragma: NO COVER
+except ImportError:  # pragma: NO COVER
+    import mock  # type: ignore
 import pytest
 
 from google.api_core import page_iterator_async
@@ -62,7 +61,7 @@ class TestAsyncIterator:
         )
 
         async_iterator = PageAsyncIteratorImpl(None, None)
-        async_iterator._next_page = AsyncMock(side_effect=[page_1, page_2, None])
+        async_iterator._next_page = mock.AsyncMock(side_effect=[page_1, page_2, None])
 
         # Consume items and check the state of the async_iterator.
         assert async_iterator.num_results == 0
@@ -102,7 +101,7 @@ class TestAsyncIterator:
         page = page_iterator_async.Page(
             iterator, ("item",), page_iterator_async._item_to_value_identity
         )
-        iterator._next_page = AsyncMock(side_effect=[page, None])
+        iterator._next_page = mock.AsyncMock(side_effect=[page, None])
 
         assert iterator.num_results == 0
 
@@ -140,7 +139,7 @@ class TestAsyncIterator:
         )
 
         iterator = PageAsyncIteratorImpl(None, None)
-        iterator._next_page = AsyncMock(side_effect=[page1, page2, None])
+        iterator._next_page = mock.AsyncMock(side_effect=[page1, page2, None])
 
         items_aiter = iterator._items_aiter()
 
@@ -163,7 +162,7 @@ class TestAsyncIterator:
     @pytest.mark.asyncio
     async def test___aiter__(self):
         async_iterator = PageAsyncIteratorImpl(None, None)
-        async_iterator._next_page = AsyncMock(side_effect=[(1, 2), (3,), None])
+        async_iterator._next_page = mock.AsyncMock(side_effect=[(1, 2), (3,), None])
 
         assert not async_iterator._started
 
@@ -252,7 +251,7 @@ class TestAsyncGRPCIterator(object):
         response1 = mock.Mock(items=["a", "b"], next_page_token="1")
         response2 = mock.Mock(items=["c"], next_page_token="2")
         response3 = mock.Mock(items=["d"], next_page_token="")
-        method = AsyncMock(side_effect=[response1, response2, response3])
+        method = mock.AsyncMock(side_effect=[response1, response2, response3])
         iterator = page_iterator_async.AsyncGRPCIterator(
             mock.sentinel.client, method, request, "items"
         )
@@ -275,7 +274,7 @@ class TestAsyncGRPCIterator(object):
         response1 = mock.Mock(items=["a", "b"], next_page_token="1")
         response2 = mock.Mock(items=["c"], next_page_token="2")
         response3 = mock.Mock(items=["d"], next_page_token="")
-        method = AsyncMock(side_effect=[response1, response2, response3])
+        method = mock.AsyncMock(side_effect=[response1, response2, response3])
         iterator = page_iterator_async.AsyncGRPCIterator(
             mock.sentinel.client, method, request, "items", max_results=3
         )

--- a/tests/asyncio/test_page_iterator_async.py
+++ b/tests/asyncio/test_page_iterator_async.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import inspect
+
 try:
     from unittest import mock
-    from unittest.mock import AsyncMock  # pragma: NO COVER
+    from unittest.mock import AsyncMock  # pragma: NO COVER  # noqa: F401
 except ImportError:  # pragma: NO COVER
     import mock  # type: ignore
 import pytest

--- a/tests/asyncio/test_page_iterator_async.py
+++ b/tests/asyncio/test_page_iterator_async.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import inspect
+from unittest import mock
 
-import mock
 import pytest
 
 from google.api_core import page_iterator_async

--- a/tests/asyncio/test_page_iterator_async.py
+++ b/tests/asyncio/test_page_iterator_async.py
@@ -15,6 +15,10 @@
 import inspect
 from unittest import mock
 
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    from mock import AsyncMock
 import pytest
 
 from google.api_core import page_iterator_async
@@ -58,7 +62,7 @@ class TestAsyncIterator:
         )
 
         async_iterator = PageAsyncIteratorImpl(None, None)
-        async_iterator._next_page = mock.AsyncMock(side_effect=[page_1, page_2, None])
+        async_iterator._next_page = AsyncMock(side_effect=[page_1, page_2, None])
 
         # Consume items and check the state of the async_iterator.
         assert async_iterator.num_results == 0
@@ -98,7 +102,7 @@ class TestAsyncIterator:
         page = page_iterator_async.Page(
             iterator, ("item",), page_iterator_async._item_to_value_identity
         )
-        iterator._next_page = mock.AsyncMock(side_effect=[page, None])
+        iterator._next_page = AsyncMock(side_effect=[page, None])
 
         assert iterator.num_results == 0
 
@@ -136,7 +140,7 @@ class TestAsyncIterator:
         )
 
         iterator = PageAsyncIteratorImpl(None, None)
-        iterator._next_page = mock.AsyncMock(side_effect=[page1, page2, None])
+        iterator._next_page = AsyncMock(side_effect=[page1, page2, None])
 
         items_aiter = iterator._items_aiter()
 
@@ -159,7 +163,7 @@ class TestAsyncIterator:
     @pytest.mark.asyncio
     async def test___aiter__(self):
         async_iterator = PageAsyncIteratorImpl(None, None)
-        async_iterator._next_page = mock.AsyncMock(side_effect=[(1, 2), (3,), None])
+        async_iterator._next_page = AsyncMock(side_effect=[(1, 2), (3,), None])
 
         assert not async_iterator._started
 
@@ -248,7 +252,7 @@ class TestAsyncGRPCIterator(object):
         response1 = mock.Mock(items=["a", "b"], next_page_token="1")
         response2 = mock.Mock(items=["c"], next_page_token="2")
         response3 = mock.Mock(items=["d"], next_page_token="")
-        method = mock.AsyncMock(side_effect=[response1, response2, response3])
+        method = AsyncMock(side_effect=[response1, response2, response3])
         iterator = page_iterator_async.AsyncGRPCIterator(
             mock.sentinel.client, method, request, "items"
         )
@@ -271,7 +275,7 @@ class TestAsyncGRPCIterator(object):
         response1 = mock.Mock(items=["a", "b"], next_page_token="1")
         response2 = mock.Mock(items=["c"], next_page_token="2")
         response3 = mock.Mock(items=["d"], next_page_token="")
-        method = mock.AsyncMock(side_effect=[response1, response2, response3])
+        method = AsyncMock(side_effect=[response1, response2, response3])
         iterator = page_iterator_async.AsyncGRPCIterator(
             mock.sentinel.client, method, request, "items", max_results=3
         )

--- a/tests/asyncio/test_rest_streaming_async.py
+++ b/tests/asyncio/test_rest_streaming_async.py
@@ -20,12 +20,12 @@ import logging
 import random
 import time
 from typing import List, AsyncIterator
-from unittest import mock
-
 try:
-    from unittest.mock import AsyncMock
-except ImportError:
-    from mock import AsyncMock
+    from unittest import mock
+    from unittest.mock import AsyncMock  # pragma: NO COVER
+except ImportError:  # pragma: NO COVER
+    import mock  # type: ignore
+
 import pytest  # noqa: I202
 
 import proto
@@ -307,7 +307,7 @@ async def test_next_not_array(response_type):
 @pytest.mark.parametrize("response_type", [EchoResponse, httpbody_pb2.HttpBody])
 async def test_cancel(response_type):
     with mock.patch.object(
-        ResponseMock, "close", new_callable=AsyncMock
+        ResponseMock, "close", new_callable=mock.AsyncMock
     ) as mock_method:
         resp = ResponseMock(responses=[], response_cls=response_type)
         itr = rest_streaming_async.AsyncResponseIterator(resp, response_type)
@@ -319,7 +319,7 @@ async def test_cancel(response_type):
 @pytest.mark.parametrize("response_type", [EchoResponse, httpbody_pb2.HttpBody])
 async def test_iterator_as_context_manager(response_type):
     with mock.patch.object(
-        ResponseMock, "close", new_callable=AsyncMock
+        ResponseMock, "close", new_callable=mock.AsyncMock
     ) as mock_method:
         resp = ResponseMock(responses=[], response_cls=response_type)
         async with rest_streaming_async.AsyncResponseIterator(resp, response_type):

--- a/tests/asyncio/test_rest_streaming_async.py
+++ b/tests/asyncio/test_rest_streaming_async.py
@@ -15,14 +15,14 @@
 # TODO: set random.seed explicitly in each test function.
 # See related issue: https://github.com/googleapis/python-api-core/issues/689.
 
-import pytest  # noqa: I202
-import mock
-
 import datetime
 import logging
 import random
 import time
 from typing import List, AsyncIterator
+from unittest import mock
+
+import pytest  # noqa: I202
 
 import proto
 

--- a/tests/asyncio/test_rest_streaming_async.py
+++ b/tests/asyncio/test_rest_streaming_async.py
@@ -20,9 +20,10 @@ import logging
 import random
 import time
 from typing import List, AsyncIterator
+
 try:
     from unittest import mock
-    from unittest.mock import AsyncMock  # pragma: NO COVER
+    from unittest.mock import AsyncMock  # pragma: NO COVER  # noqa: F401
 except ImportError:  # pragma: NO COVER
     import mock  # type: ignore
 

--- a/tests/asyncio/test_rest_streaming_async.py
+++ b/tests/asyncio/test_rest_streaming_async.py
@@ -22,6 +22,10 @@ import time
 from typing import List, AsyncIterator
 from unittest import mock
 
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    from mock import AsyncMock
 import pytest  # noqa: I202
 
 import proto
@@ -303,7 +307,7 @@ async def test_next_not_array(response_type):
 @pytest.mark.parametrize("response_type", [EchoResponse, httpbody_pb2.HttpBody])
 async def test_cancel(response_type):
     with mock.patch.object(
-        ResponseMock, "close", new_callable=mock.AsyncMock
+        ResponseMock, "close", new_callable=AsyncMock
     ) as mock_method:
         resp = ResponseMock(responses=[], response_cls=response_type)
         itr = rest_streaming_async.AsyncResponseIterator(resp, response_type)
@@ -315,7 +319,7 @@ async def test_cancel(response_type):
 @pytest.mark.parametrize("response_type", [EchoResponse, httpbody_pb2.HttpBody])
 async def test_iterator_as_context_manager(response_type):
     with mock.patch.object(
-        ResponseMock, "close", new_callable=mock.AsyncMock
+        ResponseMock, "close", new_callable=AsyncMock
     ) as mock_method:
         resp = ResponseMock(responses=[], response_cls=response_type)
         async with rest_streaming_async.AsyncResponseIterator(resp, response_type):

--- a/tests/unit/future/test__helpers.py
+++ b/tests/unit/future/test__helpers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
 
 from google.api_core.future import _helpers
 

--- a/tests/unit/future/test_polling.py
+++ b/tests/unit/future/test_polling.py
@@ -15,8 +15,8 @@
 import concurrent.futures
 import threading
 import time
+from unittest import mock
 
-import mock
 import pytest
 
 from google.api_core import exceptions, retry

--- a/tests/unit/gapic/test_method.py
+++ b/tests/unit/gapic/test_method.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import datetime
+from unittest import mock
 
-import mock
 import pytest
 
 try:

--- a/tests/unit/operations_v1/test_operations_rest_client.py
+++ b/tests/unit/operations_v1/test_operations_rest_client.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 #
 import os
-from unittest import mock
+
+try:
+    from unittest import mock
+    from unittest.mock import AsyncMock  # pragma: NO COVER  # noqa: F401
+except ImportError:  # pragma: NO COVER
+    import mock  # type: ignore
 
 import pytest
 from typing import Any, List

--- a/tests/unit/operations_v1/test_operations_rest_client.py
+++ b/tests/unit/operations_v1/test_operations_rest_client.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 import os
+from unittest import mock
 
-import mock
 import pytest
 
 try:

--- a/tests/unit/retry/test_retry_base.py
+++ b/tests/unit/retry/test_retry_base.py
@@ -14,8 +14,8 @@
 
 import itertools
 import re
+from unittest import mock
 
-import mock
 import pytest
 import requests.exceptions
 

--- a/tests/unit/retry/test_retry_streaming.py
+++ b/tests/unit/retry/test_retry_streaming.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import re
+from unittest import mock
 
-import mock
 import pytest
 
 from google.api_core import exceptions

--- a/tests/unit/retry/test_retry_streaming.py
+++ b/tests/unit/retry/test_retry_streaming.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 import re
-from unittest import mock
+
+try:
+    from unittest import mock
+    from unittest.mock import AsyncMock  # pragma: NO COVER  # noqa: F401
+except ImportError:  # pragma: NO COVER
+    import mock  # type: ignore
 
 import pytest
 

--- a/tests/unit/retry/test_retry_unary.py
+++ b/tests/unit/retry/test_retry_unary.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 
 import datetime
-import re
-from unittest import mock
-
-try:
-    from unittest.mock import AsyncMock
-except ImportError:
-    from mock import AsyncMock
 import pytest
+import re
+try:
+    from unittest import mock
+    from unittest.mock import AsyncMock  # pragma: NO COVER
+except ImportError:  # pragma: NO COVER
+    import mock  # type: ignore
 
 from google.api_core import exceptions
 from google.api_core import retry
@@ -106,7 +105,7 @@ def test_retry_target_non_retryable_error(utcnow, sleep):
 @pytest.mark.asyncio
 async def test_retry_target_warning_for_retry(utcnow, sleep):
     predicate = retry.if_exception_type(ValueError)
-    target = AsyncMock(spec=["__call__"])
+    target = mock.AsyncMock(spec=["__call__"])
 
     with pytest.warns(Warning) as exc_info:
         # Note: predicate is just a filler and doesn't affect the test

--- a/tests/unit/retry/test_retry_unary.py
+++ b/tests/unit/retry/test_retry_unary.py
@@ -15,9 +15,10 @@
 import datetime
 import pytest
 import re
+
 try:
     from unittest import mock
-    from unittest.mock import AsyncMock  # pragma: NO COVER
+    from unittest.mock import AsyncMock  # pragma: NO COVER  # noqa: F401
 except ImportError:  # pragma: NO COVER
     import mock  # type: ignore
 

--- a/tests/unit/retry/test_retry_unary.py
+++ b/tests/unit/retry/test_retry_unary.py
@@ -14,8 +14,8 @@
 
 import datetime
 import re
+from unittest import mock
 
-import mock
 import pytest
 
 from google.api_core import exceptions

--- a/tests/unit/retry/test_retry_unary.py
+++ b/tests/unit/retry/test_retry_unary.py
@@ -16,6 +16,10 @@ import datetime
 import re
 from unittest import mock
 
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    from mock import AsyncMock
 import pytest
 
 from google.api_core import exceptions
@@ -102,7 +106,7 @@ def test_retry_target_non_retryable_error(utcnow, sleep):
 @pytest.mark.asyncio
 async def test_retry_target_warning_for_retry(utcnow, sleep):
     predicate = retry.if_exception_type(ValueError)
-    target = mock.AsyncMock(spec=["__call__"])
+    target = AsyncMock(spec=["__call__"])
 
     with pytest.warns(Warning) as exc_info:
         # Note: predicate is just a filler and doesn't affect the test

--- a/tests/unit/test_bidi.py
+++ b/tests/unit/test_bidi.py
@@ -16,8 +16,8 @@ import datetime
 import logging
 import queue
 import threading
+from unittest import mock
 
-import mock
 import pytest
 
 try:

--- a/tests/unit/test_bidi.py
+++ b/tests/unit/test_bidi.py
@@ -16,7 +16,12 @@ import datetime
 import logging
 import queue
 import threading
-from unittest import mock
+
+try:
+    from unittest import mock
+    from unittest.mock import AsyncMock  # pragma: NO COVER  # noqa: F401
+except ImportError:  # pragma: NO COVER
+    import mock  # type: ignore
 
 import pytest
 

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -14,8 +14,8 @@
 
 import http.client
 import json
+from unittest import mock
 
-import mock
 import pytest
 import requests
 

--- a/tests/unit/test_extended_operation.py
+++ b/tests/unit/test_extended_operation.py
@@ -15,8 +15,8 @@
 import dataclasses
 import enum
 import typing
+from unittest import mock
 
-import mock
 import pytest
 
 from google.api_core import exceptions

--- a/tests/unit/test_grpc_helpers.py
+++ b/tests/unit/test_grpc_helpers.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
+
 import pytest
 
 try:

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 
-import mock
+from unittest import mock
+
 import pytest
 
 try:

--- a/tests/unit/test_page_iterator.py
+++ b/tests/unit/test_page_iterator.py
@@ -14,8 +14,8 @@
 
 import math
 import types
+from unittest import mock
 
-import mock
 import pytest
 
 from google.api_core import page_iterator

--- a/tests/unit/test_path_template.py
+++ b/tests/unit/test_path_template.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 from __future__ import unicode_literals
+from unittest import mock
 
-import mock
 import pytest
 
 from google.api import auth_pb2

--- a/tests/unit/test_timeout.py
+++ b/tests/unit/test_timeout.py
@@ -14,8 +14,7 @@
 
 import datetime
 import itertools
-
-import mock
+from unittest import mock
 
 from google.api_core import timeout as timeouts
 


### PR DESCRIPTION
Now that the minimum supported version of Python is 3.7, we can stop using the external mock requirement, and import it from unittest. I have also attempted to keep imports ordered.

Fixes #377
Closes #676

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-api-core/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)