### PR TITLE
fix: add type hints to ClientOptions

### DIFF
--- a/google/api_core/client_options.py
+++ b/google/api_core/client_options.py
@@ -48,6 +48,8 @@ You can also pass a mapping object.
 
 """
 
+from typing import Callable, Optional, Sequence
+
 
 class ClientOptions(object):
     """Client Options used to set options on clients.
@@ -88,15 +90,17 @@ class ClientOptions(object):
 
     def __init__(
         self,
-        api_endpoint=None,
-        client_cert_source=None,
-        client_encrypted_cert_source=None,
-        quota_project_id=None,
-        credentials_file=None,
-        scopes=None,
-        api_key=None,
-        api_audience=None,
-        universe_domain=None,
+        api_endpoint: Optional[str] = None,
+        client_cert_source: Optional[Callable[[], tuple[bytes, bytes]]] = None,
+        client_encrypted_cert_source: Optional[
+            Callable[[], tuple[str, str, bytes]]
+        ] = None,
+        quota_project_id: Optional[str] = None,
+        credentials_file: Optional[str] = None,
+        scopes: Optional[Sequence[str]] = None,
+        api_key: Optional[str] = None,
+        api_audience: Optional[str] = None,
+        universe_domain: Optional[str] = None,
     ):
         if client_cert_source and client_encrypted_cert_source:
             raise ValueError(

--- a/google/api_core/client_options.py
+++ b/google/api_core/client_options.py
@@ -118,7 +118,7 @@ class ClientOptions(object):
         self.api_audience = api_audience
         self.universe_domain = universe_domain
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "ClientOptions: " + repr(self.__dict__)
 
 

--- a/google/api_core/client_options.py
+++ b/google/api_core/client_options.py
@@ -48,7 +48,7 @@ You can also pass a mapping object.
 
 """
 
-from typing import Callable, Mapping, Optional, Sequence
+from typing import Callable, Mapping, Optional, Sequence, Tuple
 
 
 class ClientOptions(object):
@@ -57,11 +57,11 @@ class ClientOptions(object):
     Args:
         api_endpoint (Optional[str]): The desired API endpoint, e.g.,
             compute.googleapis.com
-        client_cert_source (Optional[Callable[[], (bytes, bytes)]]): A callback
+        client_cert_source (Optional[Callable[[], Tuple[bytes, bytes]]]): A callback
             which returns client certificate bytes and private key bytes both in
             PEM format. ``client_cert_source`` and ``client_encrypted_cert_source``
             are mutually exclusive.
-        client_encrypted_cert_source (Optional[Callable[[], (str, str, bytes)]]):
+        client_encrypted_cert_source (Optional[Callable[[], Tuple[str, str, bytes]]]):
             A callback which returns client certificate file path, encrypted
             private key file path, and the passphrase bytes.``client_cert_source``
             and ``client_encrypted_cert_source`` are mutually exclusive.
@@ -91,9 +91,9 @@ class ClientOptions(object):
     def __init__(
         self,
         api_endpoint: Optional[str] = None,
-        client_cert_source: Optional[Callable[[], tuple[bytes, bytes]]] = None,
+        client_cert_source: Optional[Callable[[], Tuple[bytes, bytes]]] = None,
         client_encrypted_cert_source: Optional[
-            Callable[[], tuple[str, str, bytes]]
+            Callable[[], Tuple[str, str, bytes]]
         ] = None,
         quota_project_id: Optional[str] = None,
         credentials_file: Optional[str] = None,

--- a/google/api_core/client_options.py
+++ b/google/api_core/client_options.py
@@ -48,7 +48,7 @@ You can also pass a mapping object.
 
 """
 
-from typing import Callable, Optional, Sequence
+from typing import Callable, Mapping, Optional, Sequence
 
 
 class ClientOptions(object):
@@ -122,7 +122,7 @@ class ClientOptions(object):
         return "ClientOptions: " + repr(self.__dict__)
 
 
-def from_dict(options):
+def from_dict(options: Mapping[str, object]) -> ClientOptions:
     """Construct a client options object from a mapping object.
 
     Args:


### PR DESCRIPTION
Enables https://github.com/googleapis/python-cloud-core/pull/302

I checked:
- [x] `pyright google/api_core/client_options.py`

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-api-core/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
