### PR TITLE
chore: Revert "chore: move retry async check to wrap time"

### DIFF
--- a/google/api_core/retry/retry_unary.py
+++ b/google/api_core/retry/retry_unary.py
@@ -141,7 +141,10 @@ def retry_target(
 
     for sleep in sleep_generator:
         try:
-            return target()
+            result = target()
+            if inspect.isawaitable(result):
+                warnings.warn(_ASYNC_RETRY_WARNING)
+            return result
 
         # pylint: disable=broad-except
         # This function explicitly must deal with broad exceptions.
@@ -277,8 +280,6 @@ class Retry(_BaseRetry):
             Callable: A callable that will invoke ``func`` with retry
                 behavior.
         """
-        if inspect.iscoroutinefunction(func):
-            warnings.warn(_ASYNC_RETRY_WARNING)
         if self._on_error is not None:
             on_error = self._on_error
 

--- a/tests/unit/retry/test_retry_unary.py
+++ b/tests/unit/retry/test_retry_unary.py
@@ -105,20 +105,14 @@ def test_retry_target_non_retryable_error(utcnow, sleep):
 )
 @pytest.mark.asyncio
 async def test_retry_target_warning_for_retry(utcnow, sleep):
-    """
-    retry.Retry should raise warning when wrapping an async function.
-    """
-
-    async def target():
-        pass  # pragma: NO COVER
-
-    retry_obj = retry.Retry()
+    predicate = retry.if_exception_type(ValueError)
+    target = mock.AsyncMock(spec=["__call__"])
 
     with pytest.warns(Warning) as exc_info:
-        # raise warning when wrapping an async function
-        retry_obj(target)
+        # Note: predicate is just a filler and doesn't affect the test
+        retry.retry_target(target, predicate, range(10), None)
 
-    assert len(exc_info) == 1
+    assert len(exc_info) == 2
     assert str(exc_info[0].message) == retry.retry_unary._ASYNC_RETRY_WARNING
     sleep.assert_not_called()
 


### PR DESCRIPTION
Reverts googleapis/python-api-core#668

PR #668 causes tests to fail in the `python-bigquery` repository. See build log [here](https://btx.cloud.google.com/invocations/138d2e9d-4ca7-46fa-b321-0b6482043c8c/targets/cloud-devrel%2Fclient-libraries%2Fpython%2Fgoogleapis%2Fpython-bigquery%2Fpresubmit%2Fpresubmit/log) from PR https://github.com/googleapis/python-bigquery/pull/2045.

```
E               AssertionError: Calls not found.
E               Expected: [call(method='POST', path='/projects/test-project-123/jobs', data={'jobReference': {'jobId': 'job-id', 'projectId': 'test-project-123'}}, timeout=None),
E                call(method='POST', path='/projects/test-project-123/jobs', data={'jobReference': {'jobId': 'job-id', 'projectId': 'test-project-123'}}, timeout=None),
E                call(method='GET', path='/projects/test-project-123/jobs/job-id', query_params={'projection': 'full', 'location': 'US'}, timeout=128)]
E                 Actual: [call.__code__.co_flags.__and__(128),
E                call.__code__.co_flags.__and__().__bool__(),
E                call(method='POST', path='/projects/test-project-123/jobs', data={'jobReference': {'jobId': 'job-id', 'projectId': 'test-project-123'}}, timeout=None),
E                call(method='POST', path='/projects/test-project-123/jobs', data={'jobReference': {'jobId': 'job-id', 'projectId': 'test-project-123'}}, timeout=None),
E                call.__code__.co_flags.__and__(128),
E                call.__code__.co_flags.__and__().__bool__(),
E                call(method='GET', path='/projects/test-project-123/jobs/job-id', query_params={'projection': 'full', 'location': 'US'}, timeout=128)]

```