### PR TITLE
fix: resolve the issue where rpc timeout of 0 is used when timeout expires

### DIFF
--- a/google/api_core/timeout.py
+++ b/google/api_core/timeout.py
@@ -117,7 +117,7 @@ class TimeToDeadlineTimeout(object):
 
                 # Although the `deadline` parameter in `google.api_core.retry.Retry`
                 # is deprecated, and should be treated the same as the `timeout`,
-                # it is still possible for `deadline` argument in google.api_core.retry.Retry
+                # it is still possible for `deadline` argument in `google.api_core.retry.Retry`
                 # to be larger than the `timeout`.
                 # See https://github.com/googleapis/python-api-core/issues/654
                 # Only positive non-zero timeouts are supported.

--- a/google/api_core/timeout.py
+++ b/google/api_core/timeout.py
@@ -119,11 +119,10 @@ class TimeToDeadlineTimeout(object):
                 # is deprecated, and should be treated the same as the `timeout`,
                 # it is still possible for `deadline` argument in google.api_core.retry.Retry
                 # to be larger than the `timeout`.
-                # Avoid setting negative timeout or timeout less than 5 seconds when the `timeout`
-                # has expired.
                 # See https://github.com/googleapis/python-api-core/issues/654
-                # Revert back to the original timeout when this happens
-                if remaining_timeout < 5:
+                # Only positive non-zero timeouts are supported.
+                # Revert back to the initial timeout for negative or 0 timeout values.
+                if remaining_timeout < 1:
                     remaining_timeout = self._timeout
 
                 kwargs["timeout"] = remaining_timeout

--- a/google/api_core/timeout.py
+++ b/google/api_core/timeout.py
@@ -102,8 +102,7 @@ class TimeToDeadlineTimeout(object):
         def func_with_timeout(*args, **kwargs):
             """Wrapped function that adds timeout."""
 
-            remaining_timeout = self._timeout
-            if remaining_timeout is not None:
+            if self._timeout is not None:
                 # All calculations are in seconds
                 now_timestamp = self._clock().timestamp()
 
@@ -114,8 +113,20 @@ class TimeToDeadlineTimeout(object):
                     now_timestamp = first_attempt_timestamp
 
                 time_since_first_attempt = now_timestamp - first_attempt_timestamp
-                # Avoid setting negative timeout
-                kwargs["timeout"] = max(0, self._timeout - time_since_first_attempt)
+                remaining_timeout = self._timeout - time_since_first_attempt
+
+                # Although the `deadline` parameter in `google.api_core.retry.Retry`
+                # is deprecated, and should be treated the same as the `timeout`,
+                # it is still possible for `deadline` argument in google.api_core.retry.Retry
+                # to be larger than the `timeout`.
+                # Avoid setting negative timeout or timeout less than 5 seconds when the `timeout`
+                # has expired.
+                # See https://github.com/googleapis/python-api-core/issues/654
+                # Revert back to the original timeout when this happens
+                if remaining_timeout < 5:
+                    remaining_timeout = self._timeout
+
+                kwargs["timeout"] = remaining_timeout
 
             return func(*args, **kwargs)
 

--- a/google/api_core/timeout.py
+++ b/google/api_core/timeout.py
@@ -117,8 +117,8 @@ class TimeToDeadlineTimeout(object):
 
                 # Although the `deadline` parameter in `google.api_core.retry.Retry`
                 # is deprecated, and should be treated the same as the `timeout`,
-                # it is still possible for `deadline` argument in `google.api_core.retry.Retry`
-                # to be larger than the `timeout`.
+                # it is still possible for the `deadline` argument in
+                # `google.api_core.retry.Retry` to be larger than the `timeout`.
                 # See https://github.com/googleapis/python-api-core/issues/654
                 # Only positive non-zero timeouts are supported.
                 # Revert back to the initial timeout for negative or 0 timeout values.

--- a/tests/unit/test_timeout.py
+++ b/tests/unit/test_timeout.py
@@ -82,11 +82,11 @@ class TestTimeToDeadlineTimeout(object):
         wrapped()
         target.assert_called_with(timeout=41.0)
         wrapped()
-        target.assert_called_with(timeout=3.0)
+        target.assert_called_with(timeout=42.0)
         wrapped()
-        target.assert_called_with(timeout=0.0)
+        target.assert_called_with(timeout=42.0)
         wrapped()
-        target.assert_called_with(timeout=0.0)
+        target.assert_called_with(timeout=42.0)
 
     def test_apply_no_timeout(self):
         target = mock.Mock(spec=["__call__", "__name__"], __name__="target")

--- a/tests/unit/test_timeout.py
+++ b/tests/unit/test_timeout.py
@@ -82,7 +82,7 @@ class TestTimeToDeadlineTimeout(object):
         wrapped()
         target.assert_called_with(timeout=41.0)
         wrapped()
-        target.assert_called_with(timeout=42.0)
+        target.assert_called_with(timeout=3.0)
         wrapped()
         target.assert_called_with(timeout=42.0)
         wrapped()


### PR DESCRIPTION
In PR https://github.com/googleapis/python-api-core/pull/462, the [deadline argument of google.api_core.retry.Retry](https://github.com/googleapis/python-api-core/blob/b1fae31c8c71ed65ad22a415dab2b54720c3d4ba/google/api_core/retry/retry_unary.py#L260-L261) was refactored and marked as deprecated. Although the comment below mentions that the `deadline` argument would override the `timeout`, this is not the behavior that we see when the `deadline` argument of `default_retry` is set as part of the wrapped method as is the case in this [line](https://github.com/googleapis/python-pubsub/blob/f648f65624d6096908a1e9c4364b36aaf928ce11/google/pubsub_v1/services/publisher/transports/base.py#L181), similar to the bug report in https://github.com/googleapis/python-api-core/issues/654.

https://github.com/googleapis/python-api-core/blob/b1fae31c8c71ed65ad22a415dab2b54720c3d4ba/google/api_core/retry/retry_unary.py#L194-L200


We actually have 2 separate values `deadline` and `timeout` which behave in a different manner. The `deadline` argument of `default_retry` is an overall invocation timeout, while `timeout` is the `rpc timeout`. The client will send requests (respecting the configured backoff) during the specified timeout allowed. Once the timeout is up,  the `rpc timeout` ends up being 0, but the requests keep going out because the `deadline` hasn't expired.

A simple fix is to have a reasonableness check on the `rpc timeout` to avoid sending requests with `rpc timeout` of 0.

A longer term fix is being considered where we have separate timeouts for `overall timeout` and `rpc timeout`. Currently, we just have a single `timeout` defined in [pubsub_grpc_service_config.json](https://github.com/googleapis/googleapis/blob/master/google/pubsub/v1/pubsub_grpc_service_config.json) does not provide flexibility to configure both an `overall timeout` or `rpc timeout`.

Initial testing shows that this should fix #654 

Output of test log. Previously I would see `gRPC timeout:0 seconds` as reported in #654
```
Running pytest with args: ['-p', 'vscode_pytest', '--rootdir=/usr/local/google/home/partheniou/git/gapic-generator-python', '--capture=no', '/usr/local/google/home/partheniou/git/gapic-generator-python/tests/system/test_retry.py::test_lro[grpc]']
============================= test session starts ==============================
platform linux -- Python 3.9.16, pytest-7.4.0, pluggy-1.5.0
rootdir: /usr/local/google/home/partheniou/git/gapic-generator-python
plugins: localserver-0.8.1, cov-5.0.0, asyncio-0.23.5
asyncio: mode=strict
collected 1 item

tests/system/test_retry.py 
{"timestamp": "2025-01-12 13:11:39,035", "severity": "DEBUG", "name": "google.showcase_v1beta1.services.echo.client", "message": "Created client `google.showcase_v1beta1.EchoClient`.", "serviceName": "google.showcase.v1beta1.Echo", "credentialsType": "builtins.NoneType", "universeDomain": ""}
gRPC timeout: 60.0 seconds
{"timestamp": "2025-01-12 13:11:39,042", "severity": "DEBUG", "name": "google.showcase_v1beta1.services.echo.transports.grpc", "message": "Sending request for /google.showcase.v1beta1.Echo/Block", "rpcName": "/google.showcase.v1beta1.Echo/Block", "serviceName": "google.showcase.v1beta1.Echo", "request": {"payload": "{\n  \"responseDelay\": \"60s\"\n}", "requestMethod": "grpc", "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}, "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}
{"timestamp": "2025-01-12 13:12:39,048", "severity": "DEBUG", "name": "google.api_core.retry", "message": "Retrying due to 504 Deadline Exceeded, sleeping 0.0s ..."}
gRPC timeout: 60 seconds
{"timestamp": "2025-01-12 13:12:39,084", "severity": "DEBUG", "name": "google.showcase_v1beta1.services.echo.transports.grpc", "message": "Sending request for /google.showcase.v1beta1.Echo/Block", "rpcName": "/google.showcase.v1beta1.Echo/Block", "serviceName": "google.showcase.v1beta1.Echo", "request": {"payload": "{\n  \"responseDelay\": \"60s\"\n}", "requestMethod": "grpc", "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}, "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}
{"timestamp": "2025-01-12 13:13:39,088", "severity": "DEBUG", "name": "google.api_core.retry", "message": "Retrying due to 504 Deadline Exceeded, sleeping 0.0s ..."}
gRPC timeout: 60 seconds
{"timestamp": "2025-01-12 13:13:39,114", "severity": "DEBUG", "name": "google.showcase_v1beta1.services.echo.transports.grpc", "message": "Sending request for /google.showcase.v1beta1.Echo/Block", "rpcName": "/google.showcase.v1beta1.Echo/Block", "serviceName": "google.showcase.v1beta1.Echo", "request": {"payload": "{\n  \"responseDelay\": \"60s\"\n}", "requestMethod": "grpc", "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}, "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}
{"timestamp": "2025-01-12 13:14:39,118", "severity": "DEBUG", "name": "google.api_core.retry", "message": "Retrying due to 504 Deadline Exceeded, sleeping 11.0s ..."}
gRPC timeout: 60 seconds
{"timestamp": "2025-01-12 13:14:50,085", "severity": "DEBUG", "name": "google.showcase_v1beta1.services.echo.transports.grpc", "message": "Sending request for /google.showcase.v1beta1.Echo/Block", "rpcName": "/google.showcase.v1beta1.Echo/Block", "serviceName": "google.showcase.v1beta1.Echo", "request": {"payload": "{\n  \"responseDelay\": \"60s\"\n}", "requestMethod": "grpc", "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}, "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}
{"timestamp": "2025-01-12 13:15:50,089", "severity": "DEBUG", "name": "google.api_core.retry", "message": "Retrying due to 504 Deadline Exceeded, sleeping 20.4s ..."}
gRPC timeout: 60 seconds
{"timestamp": "2025-01-12 13:16:10,474", "severity": "DEBUG", "name": "google.showcase_v1beta1.services.echo.transports.grpc", "message": "Sending request for /google.showcase.v1beta1.Echo/Block", "rpcName": "/google.showcase.v1beta1.Echo/Block", "serviceName": "google.showcase.v1beta1.Echo", "request": {"payload": "{\n  \"responseDelay\": \"60s\"\n}", "requestMethod": "grpc", "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}, "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}
{"timestamp": "2025-01-12 13:17:10,477", "severity": "DEBUG", "name": "google.api_core.retry", "message": "Retrying due to 504 Deadline Exceeded, sleeping 27.2s ..."}
gRPC timeout: 60 seconds
{"timestamp": "2025-01-12 13:17:37,729", "severity": "DEBUG", "name": "google.showcase_v1beta1.services.echo.transports.grpc", "message": "Sending request for /google.showcase.v1beta1.Echo/Block", "rpcName": "/google.showcase.v1beta1.Echo/Block", "serviceName": "google.showcase.v1beta1.Echo", "request": {"payload": "{\n  \"responseDelay\": \"60s\"\n}", "requestMethod": "grpc", "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}, "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}
{"timestamp": "2025-01-12 13:18:37,733", "severity": "DEBUG", "name": "google.api_core.retry", "message": "Retrying due to 504 Deadline Exceeded, sleeping 5.6s ..."}
gRPC timeout: 60 seconds
{"timestamp": "2025-01-12 13:18:43,345", "severity": "DEBUG", "name": "google.showcase_v1beta1.services.echo.transports.grpc", "message": "Sending request for /google.showcase.v1beta1.Echo/Block", "rpcName": "/google.showcase.v1beta1.Echo/Block", "serviceName": "google.showcase.v1beta1.Echo", "request": {"payload": "{\n  \"responseDelay\": \"60s\"\n}", "requestMethod": "grpc", "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}, "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}
{"timestamp": "2025-01-12 13:19:43,349", "severity": "DEBUG", "name": "google.api_core.retry", "message": "Retrying due to 504 Deadline Exceeded, sleeping 1.5s ..."}
gRPC timeout: 60 seconds
{"timestamp": "2025-01-12 13:19:44,817", "severity": "DEBUG", "name": "google.showcase_v1beta1.services.echo.transports.grpc", "message": "Sending request for /google.showcase.v1beta1.Echo/Block", "rpcName": "/google.showcase.v1beta1.Echo/Block", "serviceName": "google.showcase.v1beta1.Echo", "request": {"payload": "{\n  \"responseDelay\": \"60s\"\n}", "requestMethod": "grpc", "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}, "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}
{"timestamp": "2025-01-12 13:20:44,821", "severity": "DEBUG", "name": "google.api_core.retry", "message": "Retrying due to 504 Deadline Exceeded, sleeping 39.8s ..."}
gRPC timeout: 60 seconds
{"timestamp": "2025-01-12 13:21:24,597", "severity": "DEBUG", "name": "google.showcase_v1beta1.services.echo.transports.grpc", "message": "Sending request for /google.showcase.v1beta1.Echo/Block", "rpcName": "/google.showcase.v1beta1.Echo/Block", "serviceName": "google.showcase.v1beta1.Echo", "request": {"payload": "{\n  \"responseDelay\": \"60s\"\n}", "requestMethod": "grpc", "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}, "metadata": {"x-goog-api-version": "v1_20240408", "x-goog-api-client": "gl-python/3.9.16 grpc/1.67.1 gax/2.24.0 gapic/0.0.0"}}
```

Fixes https://github.com/googleapis/python-api-core/issues/654
Fixes b/387530669