### PR TITLE
fix(deps): allow protobuf 6.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,12 @@ classifiers = [
   "Topic :: Internet",
 ]
 dependencies = [
-  "googleapis-common-protos >= 1.56.2, < 2.0.dev0",
-  "protobuf >= 3.19.5, < 6.0.0.dev0, != 3.20.0, != 3.20.1, != 4.21.0, != 4.21.1, != 4.21.2, != 4.21.3, != 4.21.4, != 4.21.5",
-  "proto-plus >= 1.22.3, < 2.0.0dev",
-  "proto-plus >= 1.25.0, < 2.0.0dev; python_version >= '3.13'",
-  "google-auth >= 2.14.1, < 3.0.dev0",
-  "requests >= 2.18.0, < 3.0.0.dev0",
+  "googleapis-common-protos >= 1.56.2, < 2.0.0",
+  "protobuf >= 3.19.5, < 7.0.0, != 3.20.0, != 3.20.1, != 4.21.0, != 4.21.1, != 4.21.2, != 4.21.3, != 4.21.4, != 4.21.5",
+  "proto-plus >= 1.22.3, < 2.0.0",
+  "proto-plus >= 1.25.0, < 2.0.0; python_version >= '3.13'",
+  "google-auth >= 2.14.1, < 3.0.0",
+  "requests >= 2.18.0, < 3.0.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
See https://pypi.org/project/protobuf/6.30.0/. Also see https://github.com/googleapis/google-cloud-python/issues/13585 for the removal of `dev`