### PR TITLE
fix: cater for LROs without a result

### DIFF
--- a/google/api_core/operation.py
+++ b/google/api_core/operation.py
@@ -144,11 +144,10 @@ class Operation(polling.PollingFuture):
                 )
                 self.set_exception(exception)
             else:
-                exception = exceptions.GoogleAPICallError(
-                    "Unexpected state: Long-running operation had neither "
-                    "response nor error set."
-                )
-                self.set_exception(exception)
+                # As per the link below, `Some services might not provide a result`.
+                # Neither `error` or `response`.
+                # See https://github.com/googleapis/googleapis/blob/a6c9ed2d33105cb3dc9a0867a0a5d761b049b932/google/longrunning/operations.proto#L141
+                self.set_result(None)
 
     def _refresh_and_update(self, retry=None):
         """Refresh the operation and update the result if needed.

--- a/google/api_core/operation_async.py
+++ b/google/api_core/operation_async.py
@@ -136,11 +136,10 @@ class AsyncOperation(async_future.AsyncFuture):
                 )
                 self.set_exception(exception)
             else:
-                exception = exceptions.GoogleAPICallError(
-                    "Unexpected state: Long-running operation had neither "
-                    "response nor error set."
-                )
-                self.set_exception(exception)
+                # As per the link below, `Some services might not provide a result`.
+                # Neither `error` or `response`.
+                # See https://github.com/googleapis/googleapis/blob/a6c9ed2d33105cb3dc9a0867a0a5d761b049b932/google/longrunning/operations.proto#L141
+                self.set_result(None)
 
     async def _refresh_and_update(self, retry=async_future.DEFAULT_RETRY):
         """Refresh the operation and update the result if needed.

--- a/tests/asyncio/test_operation_async.py
+++ b/tests/asyncio/test_operation_async.py
@@ -164,7 +164,10 @@ async def test_exception():
 
 @mock.patch("asyncio.sleep", autospec=True)
 @pytest.mark.asyncio
-async def test_unexpected_result(unused_sleep):
+async def test_no_result(unused_sleep):
+    # As per the link below, `Some services might not provide a result`.
+    # Neither `error` or `response`.
+    # See https://github.com/googleapis/googleapis/blob/a6c9ed2d33105cb3dc9a0867a0a5d761b049b932/google/longrunning/operations.proto#L141
     responses = [
         make_operation_proto(),
         # Second operation response is done, but has not error or response.
@@ -172,9 +175,9 @@ async def test_unexpected_result(unused_sleep):
     ]
     future, _, _ = make_operation_future(responses)
 
-    exception = await future.exception()
+    response = await future.result()
 
-    assert "Unexpected state" in "{!r}".format(exception)
+    assert response is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -170,7 +170,10 @@ def test_exception_with_error_code():
     assert isinstance(exception, exceptions.NotFound)
 
 
-def test_unexpected_result():
+def test_no_result():
+    # As per the link below, `Some services might not provide a result`.
+    # Neither `error` or `response`.
+    # See https://github.com/googleapis/googleapis/blob/a6c9ed2d33105cb3dc9a0867a0a5d761b049b932/google/longrunning/operations.proto#L141
     responses = [
         make_operation_proto(),
         # Second operation response is done, but has not error or response.
@@ -178,9 +181,9 @@ def test_unexpected_result():
     ]
     future, _, _ = make_operation_future(responses)
 
-    exception = future.exception()
+    response = future.result()
 
-    assert "Unexpected state" in "{!r}".format(exception)
+    assert response is None
 
 
 def test__refresh_http():


### PR DESCRIPTION
Fixes https://github.com/googleapis/python-api-core/issues/809 🦕
Fixes b/403274054
