### PR TITLE
feat: Add protobuf runtime version to `x-goog-api-client` header

### DIFF
--- a/google/api_core/client_info.py
+++ b/google/api_core/client_info.py
@@ -59,6 +59,7 @@ class ClientInfo(object):
             Recommended format: ``application-or-tool-ID/major.minor.version``.
         rest_version (Optional[str]): A string with labeled versions of the
             dependencies used for REST transport.
+        protobuf_runtime_version (Optional[str]): The protobuf runtime version.
     """
 
     def __init__(
@@ -70,6 +71,7 @@ class ClientInfo(object):
         client_library_version=None,
         user_agent=None,
         rest_version=None,
+        protobuf_runtime_version=None,
     ):
         self.python_version = python_version
         self.grpc_version = grpc_version
@@ -78,6 +80,7 @@ class ClientInfo(object):
         self.client_library_version = client_library_version
         self.user_agent = user_agent
         self.rest_version = rest_version
+        self.protobuf_runtime_version = protobuf_runtime_version
 
     def to_user_agent(self):
         """Returns the user-agent string for this client info."""
@@ -104,5 +107,8 @@ class ClientInfo(object):
 
         if self.client_library_version is not None:
             ua += "gccl/{client_library_version} "
+
+        if self.protobuf_runtime_version is not None:
+            ua += "pb/{protobuf_runtime_version} "
 
         return ua.format(**self.__dict__).strip()

--- a/google/api_core/gapic_v1/client_info.py
+++ b/google/api_core/gapic_v1/client_info.py
@@ -47,6 +47,7 @@ class ClientInfo(client_info.ClientInfo):
             Recommended format: ``application-or-tool-ID/major.minor.version``.
         rest_version (Optional[str]): A string with labeled versions of the
             dependencies used for REST transport.
+        protobuf_runtime_version (Optional[str]): The protobuf runtime version.
     """
 
     def to_grpc_metadata(self):

--- a/tests/asyncio/gapic/test_method_async.py
+++ b/tests/asyncio/gapic/test_method_async.py
@@ -81,6 +81,7 @@ async def test_wrap_method_with_custom_client_info():
         api_core_version=3,
         gapic_version=4,
         client_library_version=5,
+        protobuf_runtime_version=6,
     )
     fake_call = grpc_helpers_async.FakeUnaryUnaryCall()
     method = mock.Mock(spec=aio.UnaryUnaryMultiCallable, return_value=fake_call)

--- a/tests/unit/gapic/test_method.py
+++ b/tests/unit/gapic/test_method.py
@@ -76,6 +76,7 @@ def test_wrap_method_with_custom_client_info():
         api_core_version=3,
         gapic_version=4,
         client_library_version=5,
+        protobuf_runtime_version=6,
     )
     method = mock.Mock(spec=["__call__"])
 

--- a/tests/unit/test_client_info.py
+++ b/tests/unit/test_client_info.py
@@ -46,6 +46,7 @@ def test_constructor_options():
         client_library_version="5",
         user_agent="6",
         rest_version="7",
+        protobuf_runtime_version="8",
     )
 
     assert info.python_version == "1"
@@ -55,11 +56,15 @@ def test_constructor_options():
     assert info.client_library_version == "5"
     assert info.user_agent == "6"
     assert info.rest_version == "7"
+    assert info.protobuf_runtime_version == "8"
 
 
 def test_to_user_agent_minimal():
     info = client_info.ClientInfo(
-        python_version="1", api_core_version="2", grpc_version=None
+        python_version="1",
+        api_core_version="2",
+        grpc_version=None,
+        protobuf_runtime_version=None,
     )
 
     user_agent = info.to_user_agent()
@@ -75,11 +80,14 @@ def test_to_user_agent_full():
         gapic_version="4",
         client_library_version="5",
         user_agent="app-name/1.0",
+        protobuf_runtime_version="6",
     )
 
     user_agent = info.to_user_agent()
 
-    assert user_agent == "app-name/1.0 gl-python/1 grpc/2 gax/3 gapic/4 gccl/5"
+    assert (
+        user_agent == "app-name/1.0 gl-python/1 grpc/2 gax/3 gapic/4 gccl/5 pb/6"
+    )
 
 
 def test_to_user_agent_rest():

--- a/tests/unit/test_client_info.py
+++ b/tests/unit/test_client_info.py
@@ -85,9 +85,7 @@ def test_to_user_agent_full():
 
     user_agent = info.to_user_agent()
 
-    assert (
-        user_agent == "app-name/1.0 gl-python/1 grpc/2 gax/3 gapic/4 gccl/5 pb/6"
-    )
+    assert user_agent == "app-name/1.0 gl-python/1 grpc/2 gax/3 gapic/4 gccl/5 pb/6"
 
 
 def test_to_user_agent_rest():


### PR DESCRIPTION
See https://cloud.google.com/apis/docs/system-parameters#definitions
Googlers see [b/401039328](http://b/401039328)
