### PR TITLE
fix(bidi): Allow BackgroundConsumer To Inform Caller of Fatal Exceptions with Optional Callback

### DIFF
--- a/google/api_core/bidi.py
+++ b/google/api_core/bidi.py
@@ -676,6 +676,7 @@ class BackgroundConsumer(object):
                 exc,
                 exc_info=True,
             )
+            self.stop()
 
         except Exception as exc:
             _LOGGER.exception(
@@ -683,8 +684,8 @@ class BackgroundConsumer(object):
                 _BIDIRECTIONAL_CONSUMER_NAME,
                 exc,
             )
+            self.stop()
 
-        self.stop()
         _LOGGER.info("%s exiting", _BIDIRECTIONAL_CONSUMER_NAME)
 
     def start(self):

--- a/google/api_core/bidi.py
+++ b/google/api_core/bidi.py
@@ -715,7 +715,7 @@ class BackgroundConsumer(object):
     def stop(self):
         """Stop consuming the stream and shutdown the background thread.
 
-        WARNING: Cannot be called within `_thread_main`, since it is not
+        NOTE: Cannot be called within `_thread_main`, since it is not
         possible to join a thread to itself.
         """
         with self._operational_lock:

--- a/google/api_core/bidi.py
+++ b/google/api_core/bidi.py
@@ -684,6 +684,7 @@ class BackgroundConsumer(object):
                 exc,
             )
 
+        self.stop()
         _LOGGER.info("%s exiting", _BIDIRECTIONAL_CONSUMER_NAME)
 
     def start(self):

--- a/google/api_core/bidi.py
+++ b/google/api_core/bidi.py
@@ -715,7 +715,11 @@ class BackgroundConsumer(object):
             _LOGGER.debug("Started helper thread %s", thread.name)
 
     def stop(self):
-        """Stop consuming the stream and shutdown the background thread."""
+        """Stop consuming the stream and shutdown the background thread.
+
+        WARNING: Cannot be called within `_thread_main`, since it is not
+        possible to join a thread to itself.
+        """
         with self._operational_lock:
             self._bidi_rpc.close()
 

--- a/tests/unit/test_bidi.py
+++ b/tests/unit/test_bidi.py
@@ -926,7 +926,7 @@ class TestBackgroundConsumer(object):
       lead to the consumer halting should also stop the thread and rpc.
       """
       caplog.set_level(logging.DEBUG)
-      bidi_rpc = mock.create_autospec(bidi.BidiRpc, instance=True)
+      bidi_rpc = mock.create_autospec(bidi.ResumableBidiRpc, instance=True)
       bidi_rpc.is_active = True
       on_response = mock.Mock(spec=["__call__"])
 

--- a/tests/unit/test_bidi.py
+++ b/tests/unit/test_bidi.py
@@ -923,7 +923,7 @@ class TestBackgroundConsumer(object):
         """
         https://github.com/googleapis/python-api-core/issues/820
         Exceptions thrown in the BackgroundConsumer not caught by `should_recover` / `should_terminate`
-        on the RPC should be bubbled back to the caller through `on_fatal_exception` if passed.
+        on the RPC should be bubbled back to the caller through `on_fatal_exception`, if passed.
         """
         caplog.set_level(logging.DEBUG)
 

--- a/tests/unit/test_bidi.py
+++ b/tests/unit/test_bidi.py
@@ -926,7 +926,7 @@ class TestBackgroundConsumer(object):
         lead to the consumer halting should also stop the thread and rpc.
         """
         caplog.set_level(logging.DEBUG)
-        bidi_rpc = mock.create_autospec(bidi.BidiRpc, instance=True)
+        bidi_rpc = mock.create_autospec(bidi.ResumableBidiRpc, instance=True)
         bidi_rpc.is_active = True
         on_response = mock.Mock(spec=["__call__"])
 
@@ -935,6 +935,9 @@ class TestBackgroundConsumer(object):
         consumer = bidi.BackgroundConsumer(bidi_rpc, on_response)
 
         consumer.start()
+
+        # let the background thread run for a while before exiting
+        time.sleep(0.1)
 
         # We want to make sure that close is called, which will surface the error to the caller.
         bidi_rpc.close.assert_called_once()

--- a/tests/unit/test_bidi.py
+++ b/tests/unit/test_bidi.py
@@ -919,11 +919,11 @@ class TestBackgroundConsumer(object):
         assert not error_logs, f"Found unexpected ERROR logs: {error_logs}"
         bidi_rpc.is_active = False
 
-    def test_fatal_exceptions_will_shutdown_consumer(self, caplog):
+    def test_fatal_exceptions_can_inform_consumer(self, caplog):
         """
         https://github.com/googleapis/python-api-core/issues/820
         Exceptions thrown in the BackgroundConsumer not caught by `should_recover` / `should_terminate`
-        on the RPC should be bubbled back to the caller if `reraise_exceptions` is `True`.
+        on the RPC should be bubbled back to the caller through `on_fatal_exception` if passed.
         """
         caplog.set_level(logging.DEBUG)
 
@@ -935,14 +935,16 @@ class TestBackgroundConsumer(object):
             bidi_rpc.is_active = True
             on_response = mock.Mock(spec=["__call__"])
 
+            on_fatal_exception = mock.Mock(spec=["__call__"])
+
             bidi_rpc.open.side_effect = fatal_exception
 
             consumer = bidi.BackgroundConsumer(
-                bidi_rpc, on_response, reraise_exceptions=True
+                bidi_rpc, on_response, on_fatal_exception
             )
 
-            with pytest.raises(type(fatal_exception)):
-                consumer.start()
+            consumer.start()
+            # let the background thread run for a while before exiting
+            time.sleep(0.1)
 
-                # let the background thread run for a while before exiting
-                time.sleep(0.1)
+            on_fatal_exception.assert_called_once_with(fatal_exception)

--- a/tests/unit/test_bidi.py
+++ b/tests/unit/test_bidi.py
@@ -918,3 +918,23 @@ class TestBackgroundConsumer(object):
         error_logs = [r.message for r in caplog.records if r.levelname == "ERROR"]
         assert not error_logs, f"Found unexpected ERROR logs: {error_logs}"
         bidi_rpc.is_active = False
+
+    def test_fatal_exceptions_will_shutdown_consumer(self, caplog):
+      """
+      https://github.com/googleapis/python-api-core/issues/820
+      Exceptions thrown in the BackgroundConsumer that
+      lead to the consumer halting should also stop the thread and rpc.
+      """
+      caplog.set_level(logging.DEBUG)
+      bidi_rpc = mock.create_autospec(bidi.BidiRpc, instance=True)
+      bidi_rpc.is_active = True
+      on_response = mock.Mock(spec=["__call__"])
+
+      bidi_rpc.open.side_effect = ValueError()
+
+      consumer = bidi.BackgroundConsumer(bidi_rpc, on_response)
+
+      consumer.start()
+
+      # We want to make sure that close is called, which will surface the error to the caller.
+      bidi_rpc.close.assert_called_once()

--- a/tests/unit/test_bidi.py
+++ b/tests/unit/test_bidi.py
@@ -920,21 +920,21 @@ class TestBackgroundConsumer(object):
         bidi_rpc.is_active = False
 
     def test_fatal_exceptions_will_shutdown_consumer(self, caplog):
-      """
-      https://github.com/googleapis/python-api-core/issues/820
-      Exceptions thrown in the BackgroundConsumer that
-      lead to the consumer halting should also stop the thread and rpc.
-      """
-      caplog.set_level(logging.DEBUG)
-      bidi_rpc = mock.create_autospec(bidi.BidiRpc, instance=True)
-      bidi_rpc.is_active = True
-      on_response = mock.Mock(spec=["__call__"])
+        """
+        https://github.com/googleapis/python-api-core/issues/820
+        Exceptions thrown in the BackgroundConsumer that
+        lead to the consumer halting should also stop the thread and rpc.
+        """
+        caplog.set_level(logging.DEBUG)
+        bidi_rpc = mock.create_autospec(bidi.BidiRpc, instance=True)
+        bidi_rpc.is_active = True
+        on_response = mock.Mock(spec=["__call__"])
 
-      bidi_rpc.open.side_effect = ValueError()
+        bidi_rpc.open.side_effect = ValueError()
 
-      consumer = bidi.BackgroundConsumer(bidi_rpc, on_response)
+        consumer = bidi.BackgroundConsumer(bidi_rpc, on_response)
 
-      consumer.start()
+        consumer.start()
 
-      # We want to make sure that close is called, which will surface the error to the caller.
-      bidi_rpc.close.assert_called_once()
+        # We want to make sure that close is called, which will surface the error to the caller.
+        bidi_rpc.close.assert_called_once()


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-api-core/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

BEGIN_COMMIT_OVERRIDE
fix: Allow BackgroundConsumer To Inform Caller of Fatal Exceptions with Optional Callback
END_COMMIT_OVERRIDE

Fixes #820 
