### PR TITLE
feat: provide and use Python version support check

### DIFF
--- a/google/api_core/__init__.py
+++ b/google/api_core/__init__.py
@@ -17,6 +17,8 @@
 This package contains common code and utilities used by Google client libraries.
 """
 
+from google.api_core import _python_version_support
 from google.api_core import version as api_core_version
 
 __version__ = api_core_version.__version__
+check_python_version = _python_version_support.check_python_version

--- a/google/api_core/__init__.py
+++ b/google/api_core/__init__.py
@@ -33,6 +33,7 @@ check_dependency_versions = _python_package_support.check_dependency_versions
 warn_deprecation_for_versions_less_than = (
     _python_package_support.warn_deprecation_for_versions_less_than
 )
+DependencyConstraint = _python_package_support.DependencyConstraint
 
 # perform version checks against api_core, and emit warnings if needed
 check_python_version(package="google.api_core")

--- a/google/api_core/__init__.py
+++ b/google/api_core/__init__.py
@@ -23,7 +23,7 @@ from google.api_core import version as api_core_version
 
 __version__ = api_core_version.__version__
 
-# TODO: Until dependent artifacts require this version of
+# NOTE: Until dependent artifacts require this version of
 # google.api_core, the functionality below must be made available
 # manually in those artifacts.
 

--- a/google/api_core/__init__.py
+++ b/google/api_core/__init__.py
@@ -27,12 +27,13 @@ __version__ = api_core_version.__version__
 # google.api_core, the functionality below must be made available
 # manually in those artifacts.
 
+# expose dependency checks for external callers
 check_python_version = _python_version_support.check_python_version
-check_python_version(package="google.api_core")
-
 check_dependency_versions = _python_package_support.check_dependency_versions
-check_dependency_versions("google.api_core")
-
 warn_deprecation_for_versions_less_than = (
     _python_package_support.warn_deprecation_for_versions_less_than
 )
+
+# perform version checks against api_core, and emit warnings if needed
+check_python_version(package="google.api_core")
+check_dependency_versions("google.api_core")

--- a/google/api_core/__init__.py
+++ b/google/api_core/__init__.py
@@ -23,6 +23,10 @@ from google.api_core import version as api_core_version
 
 __version__ = api_core_version.__version__
 
+# TODO: Until dependent artifacts require this version of
+# google.api_core, the functionality below must be made available
+# manually in those artifacts.
+
 check_python_version = _python_version_support.check_python_version
 check_python_version(package="google.api_core")
 

--- a/google/api_core/__init__.py
+++ b/google/api_core/__init__.py
@@ -22,3 +22,4 @@ from google.api_core import version as api_core_version
 
 __version__ = api_core_version.__version__
 check_python_version = _python_version_support.check_python_version
+check_python_version(package="package google-api-core (google.api_core)")

--- a/google/api_core/__init__.py
+++ b/google/api_core/__init__.py
@@ -24,7 +24,7 @@ from google.api_core import version as api_core_version
 __version__ = api_core_version.__version__
 
 check_python_version = _python_version_support.check_python_version
-check_python_version(package="package google-api-core (google.api_core)")
+check_python_version(package="google.api_core")
 
 check_dependency_versions = _python_package_support.check_dependency_versions
-check_dependency_versions("google-api-core (google.api_core)")
+check_dependency_versions("google.api_core")

--- a/google/api_core/__init__.py
+++ b/google/api_core/__init__.py
@@ -17,9 +17,14 @@
 This package contains common code and utilities used by Google client libraries.
 """
 
+from google.api_core import _python_package_support
 from google.api_core import _python_version_support
 from google.api_core import version as api_core_version
 
 __version__ = api_core_version.__version__
+
 check_python_version = _python_version_support.check_python_version
 check_python_version(package="package google-api-core (google.api_core)")
+
+check_dependency_versions = _python_package_support.check_dependency_versions
+check_dependency_versions("google-api-core (google.api_core)")

--- a/google/api_core/__init__.py
+++ b/google/api_core/__init__.py
@@ -32,3 +32,5 @@ check_python_version(package="google.api_core")
 
 check_dependency_versions = _python_package_support.check_dependency_versions
 check_dependency_versions("google.api_core")
+
+warn_deprecation_for_versions_less_than = _python_package_support.warn_deprecation_for_versions_less_than

--- a/google/api_core/__init__.py
+++ b/google/api_core/__init__.py
@@ -33,4 +33,6 @@ check_python_version(package="google.api_core")
 check_dependency_versions = _python_package_support.check_dependency_versions
 check_dependency_versions("google.api_core")
 
-warn_deprecation_for_versions_less_than = _python_package_support.warn_deprecation_for_versions_less_than
+warn_deprecation_for_versions_less_than = (
+    _python_package_support.warn_deprecation_for_versions_less_than
+)

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -115,7 +115,7 @@ def warn_deprecation_for_versions_less_than(
 def check_dependency_versions(dependent_package: str):
     """Bundle checks for all package dependencies.
 
-    This function can be called by all depndents of google.api_core,
+    This function can be called by all dependents of google.api_core,
     to emit needed deprecation warnings for any of their
     dependencies. The dependencies to check should be updated here.
 

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -96,7 +96,7 @@ def warn_deprecation_for_versions_less_than(
         not dependent_import_package
         or not dependency_import_package
         or not next_supported_version
-    ):
+    ):  # pragma: NO COVER
         return
     version_used = get_dependency_version(dependency_import_package)
     if not version_used:

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -68,9 +68,9 @@ def warn_deprecation_for_versions_less_than(
     """Issue any needed deprecation warnings for `dependency_import_package`.
 
     If `dependency_import_package` is installed at a version less than
-    `next_supported_versions`, this issues a warning using either a
+    `next_supported_version`, this issues a warning using either a
     default `message_template` or one provided by the user. The
-    default `message_template informs users that they will not receive
+    default `message_template` informs the user that they will not receive
     future updates `dependent_import_package` if
     `dependency_import_package` is somehow pinned to a version lower
     than `next_supported_version`.
@@ -84,10 +84,10 @@ def warn_deprecation_for_versions_less_than(
       message_template: A custom default message template to replace
         the default. This `message_template` is treated as an
         f-string, where the following variables are defined:
-        `dependency_import_package`, `dependent_import_package`;
-        `dependency_packages` and `dependent_packages`, which contain both the
-         distribution and import packages for the dependency and the dependent,
-         respectively; and `next_supported_version`, and `version_used`, which
+        `dependency_import_package`, `dependent_import_package` and
+        `dependency_package`, `dependent_package`, which contain both the
+         import and distribution packages for the dependency and the dependent,
+         respectively; and `next_supported_version` and `version_used`, which
          refer to supported and currently-used versions of the dependency.
 
     """
@@ -102,34 +102,34 @@ def warn_deprecation_for_versions_less_than(
         return
     if version_used < parse_version(next_supported_version):
         (
-            dependency_packages,
+            dependency_package,
             dependency_distribution_package,
         ) = _get_distribution_and_import_packages(dependency_import_package)
         (
-            dependent_packages,
+            dependent_package,
             dependent_distribution_package,
         ) = _get_distribution_and_import_packages(dependent_import_package)
         message_template = message_template or _flatten_message(
             """
-            DEPRECATION: Package {dependent_packages} depends on
-            {dependency_packages}, currently installed at version
+            DEPRECATION: Package {dependent_package} depends on
+            {dependency_package}, currently installed at version
             {version_used.__str__}. Future updates to
-            {dependent_packages} will require {dependency_packages} at
+            {dependent_package} will require {dependency_package} at
             version {next_supported_version} or higher. Please ensure
             that either (a) your Python environment doesn't pin the
-            version of {dependency_packages}, so that updates to
-            {dependent_packages} can require the higher version, or
+            version of {dependency_package}, so that updates to
+            {dependent_package} can require the higher version, or
             (b) you manually update your Python environment to use at
             least version {next_supported_version} of
-            {dependency_packages}.
+            {dependency_package}.
             """
         )
         logging.warning(
             message_template.format(
                 dependent_import_package=dependent_import_package,
                 dependency_import_package=dependency_import_package,
-                dependency_packages=dependency_packages,
-                dependent_packages=dependent_packages,
+                dependency_package=dependency_package,
+                dependent_package=dependent_package,
                 next_supported_version=next_supported_version,
                 version_used=version_used,
             )

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -49,7 +49,7 @@ def get_dependency_version(dependency_name: str) -> Optional[PackagingVersion]:
 
         # TODO(https://github.com/googleapis/python-api-core/issues/835): Remove
         # this code path once we drop support for Python 3.7
-        else:
+        else:  # pragma: NO COVER
             # Use pkg_resources, which is part of setuptools.
             import pkg_resources
 

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -66,6 +66,7 @@ def warn_deprecation_for_versions_less_than(
     dependent_import_package: str,
     dependency_import_package: str,
     next_supported_version: str,
+    recommended_version: Optional[str] = None,
     message_template: Optional[str] = None,
 ):
     """Issue any needed deprecation warnings for `dependency_import_package`.
@@ -84,6 +85,8 @@ def warn_deprecation_for_versions_less_than(
       dependency_import_package: The import name of the dependency to check.
       next_supported_version: The dependency_import_package version number
         below which a deprecation warning will be logged.
+      recommended_version: If provided, the recommended next version, which
+        could be higher than `next_supported_version`.
       message_template: A custom default message template to replace
         the default. This `message_template` is treated as an
         f-string, where the following variables are defined:
@@ -118,17 +121,22 @@ def warn_deprecation_for_versions_less_than(
             dependent_package,
             dependent_distribution_package,
         ) = _get_distribution_and_import_packages(dependent_import_package)
+
+        recommendation = (
+            " (we recommend {recommended_version})" if recommended_version else ""
+        )
         message_template = message_template or _flatten_message(
             """
             DEPRECATION: Package {dependent_package} depends on
             {dependency_package}, currently installed at version
             {version_used_string}. Future updates to
             {dependent_package} will require {dependency_package} at
-            version {next_supported_version} or higher. Please ensure
-            that either (a) your Python environment doesn't pin the
-            version of {dependency_package}, so that updates to
-            {dependent_package} can require the higher version, or
-            (b) you manually update your Python environment to use at
+            version {next_supported_version} or
+            higher{recommendation}. Please ensure that either (a) your
+            Python environment doesn't pin the version of
+            {dependency_package}, so that updates to
+            {dependent_package} can require the higher version, or (b)
+            you manually update your Python environment to use at
             least version {next_supported_version} of
             {dependency_package}.
             """
@@ -142,6 +150,7 @@ def warn_deprecation_for_versions_less_than(
                 dependency_package=dependency_package,
                 dependent_package=dependent_package,
                 next_supported_version=next_supported_version,
+                recommendation=recommendation,
                 version_used=version_used,
                 version_used_string=version_used_string,
             ),
@@ -162,5 +171,5 @@ def check_dependency_versions(dependent_import_package: str):
 
     """
     warn_deprecation_for_versions_less_than(
-        dependent_import_package, "google.protobuf", "4.25.8"
+        dependent_import_package, "google.protobuf", "4.25.8", recommended_version="6.x"
     )

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -62,6 +62,25 @@ def warn_deprecation_for_versions_less_than(
     next_supported_version: str,
     message_template: Optional[str] = None,
 ):
+    """Issue a deprecation warning for outdated versions of `dependency_name`.
+
+    If `dependency_name` is installed at a version less than
+    `next_supported_versions`, this issues a warning using either a
+    default `message_template` or one provided by the user. The
+    default `message_template informs users that they will not receive
+    future updates `dependent_package` if `dependency_name` is somehow
+    pinned to a version lower than `next_supported_version`.
+
+    Args:
+      dependent_package: The distribution name of the package that needs `dependency_name`.
+      dependency_name: The distribution name oft he dependency to check.
+      next_supported_version: The version number below which a deprecation warning will be logged.
+      message_template: A custom default message template to replace
+        the default. This `message_template` is treated as an
+        f-string, where the following variables are defined:
+        `dependency_name`, `dependent_package`,
+        `next_supported_version`, and `version_used`.
+    """
     if not dependent_package or not dependency_name or not next_supported_version:
         return
     version_used = get_dependency_version(dependency_name)

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -14,7 +14,7 @@
 
 """Code to check versions of dependencies used by Google Cloud Client Libraries."""
 
-import logging
+import warnings
 import sys
 from typing import Optional
 from ._python_version_support import (
@@ -128,7 +128,7 @@ def warn_deprecation_for_versions_less_than(
             {dependency_package}.
             """
         )
-        logging.warning(
+        warnings.warn(
             message_template.format(
                 dependent_import_package=dependent_import_package,
                 dependency_import_package=dependency_import_package,

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -40,6 +40,7 @@ def get_dependency_version(dependency_name: str) -> Optional[PackagingVersion]:
     try:
         if sys.version_info >= (3, 8):
             from importlib import metadata
+
             version_string = metadata.version(dependency_name)
             return parse_version(version_string)
 
@@ -47,6 +48,7 @@ def get_dependency_version(dependency_name: str) -> Optional[PackagingVersion]:
         else:
             # Use pkg_resources, which is part of setuptools.
             import pkg_resources
+
             version_string = pkg_resources.get_distribution(dependency_name).version
             return parse_version(version_string)
 
@@ -54,10 +56,12 @@ def get_dependency_version(dependency_name: str) -> Optional[PackagingVersion]:
         return None
 
 
-def warn_deprecation_for_versions_less_than(dependent_package:str,
-                                            dependency_name:str,
-                                            next_supported_version:str,
-                                            message_template: Optional[str] = None):
+def warn_deprecation_for_versions_less_than(
+    dependent_package: str,
+    dependency_name: str,
+    next_supported_version: str,
+    message_template: Optional[str] = None,
+):
     if not dependent_package or not dependency_name or not next_supported_version:
         return
     version_used = get_dependency_version(dependency_name)
@@ -83,7 +87,11 @@ def warn_deprecation_for_versions_less_than(dependent_package:str,
                 dependency_name=dependency_name,
                 next_supported_version=next_supported_version,
                 version_used=version_used,
-            ))
+            )
+        )
+
 
 def check_dependency_versions(dependent_package: str):
-    warn_deprecation_for_versions_less_than(dependent_package, "protobuf (google.protobuf)", "4.25.8")
+    warn_deprecation_for_versions_less_than(
+        dependent_package, "protobuf (google.protobuf)", "4.25.8"
+    )

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -104,7 +104,9 @@ def warn_deprecation_for_versions_less_than(
         or not next_supported_version
     ):  # pragma: NO COVER
         return
-    (version_used, version_used_string) = get_dependency_version(dependency_import_package)
+    (version_used, version_used_string) = get_dependency_version(
+        dependency_import_package
+    )
     if not version_used:
         return
     if version_used < parse_version(next_supported_version):
@@ -141,9 +143,9 @@ def warn_deprecation_for_versions_less_than(
                 dependent_package=dependent_package,
                 next_supported_version=next_supported_version,
                 version_used=version_used,
-                version_used_string=version_used_string
+                version_used_string=version_used_string,
             ),
-            FutureWarning
+            FutureWarning,
         )
 
 

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -74,28 +74,28 @@ def get_dependency_version(
 def warn_deprecation_for_versions_less_than(
     dependent_import_package: str,
     dependency_import_package: str,
-    next_supported_version: str,
+    minimum_fully_supported_version: str,
     recommended_version: Optional[str] = None,
     message_template: Optional[str] = None,
 ):
     """Issue any needed deprecation warnings for `dependency_import_package`.
 
     If `dependency_import_package` is installed at a version less than
-    `next_supported_version`, this issues a warning using either a
+    `minimum_fully_supported_version`, this issues a warning using either a
     default `message_template` or one provided by the user. The
     default `message_template` informs the user that they will not receive
     future updates for `dependent_import_package` if
     `dependency_import_package` is somehow pinned to a version lower
-    than `next_supported_version`.
+    than `minimum_fully_supported_version`.
 
     Args:
       dependent_import_package: The import name of the package that
         needs `dependency_import_package`.
       dependency_import_package: The import name of the dependency to check.
-      next_supported_version: The dependency_import_package version number
+      minimum_fully_supported_version: The dependency_import_package version number
         below which a deprecation warning will be logged.
       recommended_version: If provided, the recommended next version, which
-        could be higher than `next_supported_version`.
+        could be higher than `minimum_fully_supported_version`.
       message_template: A custom default message template to replace
         the default. This `message_template` is treated as an
         f-string, where the following variables are defined:
@@ -105,7 +105,7 @@ def warn_deprecation_for_versions_less_than(
         `dependent_package` , which contain the import packages, the
         distribution packages, and pretty string with both the
         distribution and import packages for the dependency and the
-        dependent, respectively; and `next_supported_version`,
+        dependent, respectively; and `minimum_fully_supported_version`,
         `version_used`, and `version_used_string`, which refer to supported
         and currently-used versions of the dependency.
 
@@ -113,13 +113,13 @@ def warn_deprecation_for_versions_less_than(
     if (
         not dependent_import_package
         or not dependency_import_package
-        or not next_supported_version
+        or not minimum_fully_supported_version
     ):  # pragma: NO COVER
         return
     dependency_version = get_dependency_version(dependency_import_package)
     if not dependency_version.version:
         return
-    if dependency_version.version < parse_version(next_supported_version):
+    if dependency_version.version < parse_version(minimum_fully_supported_version):
         (
             dependency_package,
             dependency_distribution_package,
@@ -138,13 +138,13 @@ def warn_deprecation_for_versions_less_than(
             {dependency_package}, currently installed at version
             {version_used_string}. Future updates to
             {dependent_package} will require {dependency_package} at
-            version {next_supported_version} or
+            version {minimum_fully_supported_version} or
             higher{recommendation}. Please ensure that either (a) your
             Python environment doesn't pin the version of
             {dependency_package}, so that updates to
             {dependent_package} can require the higher version, or (b)
             you manually update your Python environment to use at
-            least version {next_supported_version} of
+            least version {minimum_fully_supported_version} of
             {dependency_package}.
             """
         )
@@ -156,7 +156,7 @@ def warn_deprecation_for_versions_less_than(
                 dependency_distribution_package=dependency_distribution_package,
                 dependency_package=dependency_package,
                 dependent_package=dependent_package,
-                next_supported_version=next_supported_version,
+                minimum_fully_supported_version=minimum_fully_supported_version,
                 recommendation=recommendation,
                 version_used=dependency_version.version,
                 version_used_string=dependency_version.version_string,

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -27,8 +27,24 @@ from ._python_version_support import (
 
 from packaging.version import parse as parse_version
 
-DependencyVersion = namedtuple("DependencyVersion", ["version", "version_string"])
+# Here we list all the packages for which we want to issue warnings
+# about deprecated and unsupported versions.
+_DependencyConstraint = namedtuple(
+    "_DependencyConstraint",
+    ["package_name", "minimum_fully_supported_version", "recommended_version"],
+)
+_PACKAGE_DEPENDENCY_WARNINGS = [
+    _DependencyConstraint(
+        "google.protobuf",
+        minimum_fully_supported_version="4.25.8",
+        recommended_version="6.x",
+    )
+]
 
+
+DependencyVersion = namedtuple("DependencyVersion", ["version", "version_string"])
+# Version string we provide in a DependencyVersion when we can't determine the version of a
+# package.
 UNKNOWN_VERSION_STRING = "--"
 
 
@@ -177,6 +193,10 @@ def check_dependency_versions(consumer_import_package: str):
         dependencies we're checking.
 
     """
-    warn_deprecation_for_versions_less_than(
-        consumer_import_package, "google.protobuf", "4.25.8", recommended_version="6.x"
-    )
+    for package_info in _PACKAGE_DEPENDENCY_WARNINGS:
+        warn_deprecation_for_versions_less_than(
+            consumer_import_package,
+            package_info.package_name,
+            package_info.minimum_fully_supported_version,
+            recommended_version=package_info.recommended_version,
+        )

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -72,9 +72,11 @@ def warn_deprecation_for_versions_less_than(
     pinned to a version lower than `next_supported_version`.
 
     Args:
-      dependent_package: The distribution name of the package that needs `dependency_name`.
+      dependent_package: The distribution name of the package that
+        needs `dependency_name`.
       dependency_name: The distribution name oft he dependency to check.
-      next_supported_version: The version number below which a deprecation warning will be logged.
+      next_supported_version: The version number below which a deprecation
+        warning will be logged.
       message_template: A custom default message template to replace
         the default. This `message_template` is treated as an
         f-string, where the following variables are defined:
@@ -111,6 +113,17 @@ def warn_deprecation_for_versions_less_than(
 
 
 def check_dependency_versions(dependent_package: str):
+    """Bundle checks for all package dependencies.
+
+    This function can be called by all depndents of google.api_core,
+    to emit needed deprecation warnings for any of their
+    dependencies. The dependencies to check should be updated here.
+
+    Args:
+      dependent_package: The distribution name of the calling package, whose
+        dependencies we're checking.
+
+    """
     warn_deprecation_for_versions_less_than(
         dependent_package, "protobuf (google.protobuf)", "4.25.8"
     )

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -29,12 +29,12 @@ from packaging.version import parse as parse_version
 
 # Here we list all the packages for which we want to issue warnings
 # about deprecated and unsupported versions.
-_DependencyConstraint = namedtuple(
-    "_DependencyConstraint",
+DependencyConstraint = namedtuple(
+    "DependencyConstraint",
     ["package_name", "minimum_fully_supported_version", "recommended_version"],
 )
 _PACKAGE_DEPENDENCY_WARNINGS = [
-    _DependencyConstraint(
+    DependencyConstraint(
         "google.protobuf",
         minimum_fully_supported_version="4.25.8",
         recommended_version="6.x",
@@ -181,19 +181,26 @@ def warn_deprecation_for_versions_less_than(
         )
 
 
-def check_dependency_versions(consumer_import_package: str):
+def check_dependency_versions(
+    consumer_import_package: str, *package_dependency_warnings: DependencyConstraint
+):
     """Bundle checks for all package dependencies.
 
-    This function can be called by all dependents of google.api_core,
+    This function can be called by all consumers of google.api_core,
     to emit needed deprecation warnings for any of their
-    dependencies. The dependencies to check should be updated here.
+    dependencies. The dependencies to check can be passed as arguments, or if
+    none are provided, it will default to the list in
+    `_PACKAGE_DEPENDENCY_WARNINGS`.
 
     Args:
       consumer_import_package: The distribution name of the calling package, whose
         dependencies we're checking.
-
+      *package_dependency_warnings: A variable number of DependencyConstraint
+        objects, each specifying a dependency to check.
     """
-    for package_info in _PACKAGE_DEPENDENCY_WARNINGS:
+    if not package_dependency_warnings:
+        package_dependency_warnings = tuple(_PACKAGE_DEPENDENCY_WARNINGS)
+    for package_info in package_dependency_warnings:
         warn_deprecation_for_versions_less_than(
             consumer_import_package,
             package_info.package_name,

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -16,7 +16,7 @@
 
 import warnings
 import sys
-from typing import Optional
+from typing import Optional, Tuple
 from ._python_version_support import (
     _flatten_message,
     _get_distribution_and_import_packages,
@@ -25,7 +25,9 @@ from ._python_version_support import (
 from packaging.version import parse as parse_version, Version as PackagingVersion
 
 
-def get_dependency_version(dependency_name: str) -> Optional[PackagingVersion]:
+def get_dependency_version(
+    dependency_name: str,
+) -> Tuple[Optional[PackagingVersion], str]:
     """Get the parsed version of an installed package dependency.
 
     This function checks for an installed package and returns its version
@@ -36,8 +38,9 @@ def get_dependency_version(dependency_name: str) -> Optional[PackagingVersion]:
         dependency_name: The distribution name of the package (e.g., 'requests').
 
     Returns:
-        A `packaging.version.Version` object, or `None` if the package
-        is not found or another error occurs during version discovery.
+        A tuple containing the `packaging.version.Version` object and the
+        version string, or `(None, '--')` if the package is not found or
+        another error occurs during version discovery.
     """
     try:
         if sys.version_info >= (3, 8):
@@ -90,9 +93,9 @@ def warn_deprecation_for_versions_less_than(
         `dependent_package` , which contain the import packages, the
         distribution packages, and pretty string with both the
         distribution and import packages for the dependency and the
-        dependent, respectively; and `next_supported_version` and
-        `version_used`, which refer to supported and currently-used
-        versions of the dependency.
+        dependent, respectively; and `next_supported_version`,
+        `version_used`, and `version_used_string`, which refer to supported
+        and currently-used versions of the dependency.
 
     """
     if (
@@ -138,7 +141,9 @@ def warn_deprecation_for_versions_less_than(
                 dependent_package=dependent_package,
                 next_supported_version=next_supported_version,
                 version_used=version_used,
-            )
+                version_used_string=version_used_string
+            ),
+            FutureWarning
         )
 
 

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -47,7 +47,8 @@ def get_dependency_version(dependency_name: str) -> Optional[PackagingVersion]:
             version_string = metadata.version(dependency_name)
             return parse_version(version_string)
 
-        # TODO: Remove this code path once we drop support for Python 3.7
+        # TODO(https://github.com/googleapis/python-api-core/issues/835): Remove
+        # this code path once we drop support for Python 3.7
         else:
             # Use pkg_resources, which is part of setuptools.
             import pkg_resources

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -29,6 +29,8 @@ from packaging.version import parse as parse_version
 
 DependencyVersion = namedtuple("DependencyVersion", ["version", "version_string"])
 
+UNKNOWN_VERSION_STRING = "--"
+
 
 def get_dependency_version(
     dependency_name: str,
@@ -43,9 +45,11 @@ def get_dependency_version(
         dependency_name: The distribution name of the package (e.g., 'requests').
 
     Returns:
-        A DependencyVersion namedtuple with `version` and `version_string`
-        attributes, or `DependencyVersion(None, '--')` if the package is not
-        found or another error occurs during version discovery.
+        A DependencyVersion namedtuple with `version` and
+        `version_string` attributes, or `DependencyVersion(None,
+        UNKNOWN_VERSION_STRING)` if the package is not found or
+        another error occurs during version discovery.
+
     """
     try:
         if sys.version_info >= (3, 8):
@@ -64,7 +68,7 @@ def get_dependency_version(
             return DependencyVersion(parse_version(version_string), version_string)
 
     except Exception:
-        return DependencyVersion(None, "--")
+        return DependencyVersion(None, UNKNOWN_VERSION_STRING)
 
 
 def warn_deprecation_for_versions_less_than(

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -44,7 +44,7 @@ def get_dependency_version(dependency_name: str) -> Optional[PackagingVersion]:
             from importlib import metadata
 
             version_string = metadata.version(dependency_name)
-            return parse_version(version_string)
+            return (parse_version(version_string), version_string)
 
         # TODO(https://github.com/googleapis/python-api-core/issues/835): Remove
         # this code path once we drop support for Python 3.7
@@ -53,10 +53,10 @@ def get_dependency_version(dependency_name: str) -> Optional[PackagingVersion]:
             import pkg_resources
 
             version_string = pkg_resources.get_distribution(dependency_name).version
-            return parse_version(version_string)
+            return (parse_version(version_string), version_string)
 
     except Exception:
-        return None
+        return (None, "--")
 
 
 def warn_deprecation_for_versions_less_than(
@@ -101,7 +101,7 @@ def warn_deprecation_for_versions_less_than(
         or not next_supported_version
     ):  # pragma: NO COVER
         return
-    version_used = get_dependency_version(dependency_import_package)
+    (version_used, version_used_string) = get_dependency_version(dependency_import_package)
     if not version_used:
         return
     if version_used < parse_version(next_supported_version):
@@ -117,7 +117,7 @@ def warn_deprecation_for_versions_less_than(
             """
             DEPRECATION: Package {dependent_package} depends on
             {dependency_package}, currently installed at version
-            {version_used.__str__()}. Future updates to
+            {version_used_string}. Future updates to
             {dependent_package} will require {dependency_package} at
             version {next_supported_version} or higher. Please ensure
             that either (a) your Python environment doesn't pin the

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -1,0 +1,89 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Code to check versions of dependencies used by Google Cloud Client Libraries."""
+
+import logging
+import sys
+from typing import Optional
+from ._python_version_support import _flatten_message
+
+# It is a good practice to alias the Version class for clarity in type hints.
+from packaging.version import parse as parse_version, Version as PackagingVersion
+
+
+def get_dependency_version(dependency_name: str) -> Optional[PackagingVersion]:
+    """Get the parsed version of an installed package dependency.
+
+    This function checks for an installed package and returns its version
+    as a `packaging.version.Version` object for safe comparison. It handles
+    both modern (Python 3.8+) and legacy (Python 3.7) environments.
+
+    Args:
+        dependency_name: The distribution name of the package (e.g., 'requests').
+
+    Returns:
+        A `packaging.version.Version` object, or `None` if the package
+        is not found or another error occurs during version discovery.
+    """
+    try:
+        if sys.version_info >= (3, 8):
+            from importlib import metadata
+            version_string = metadata.version(dependency_name)
+            return parse_version(version_string)
+
+        # TODO: Remove this code path once we drop support for Python 3.7
+        else:
+            # Use pkg_resources, which is part of setuptools.
+            import pkg_resources
+            version_string = pkg_resources.get_distribution(dependency_name).version
+            return parse_version(version_string)
+
+    except:
+        return None
+
+
+def warn_deprecation_for_versions_less_than(dependent_package:str,
+                                            dependency_name:str,
+                                            next_supported_version:str,
+                                            message_template: Optional[str] = None):
+    if not dependent_package or not dependency_name or not next_supported_version:
+        return
+    version_used = get_dependency_version(dependency_name)
+    if not version_used:
+        return
+    if version_used < parse_version(next_supported_version):
+        message_template = message_template or _flatten_message(
+            """DEPRECATION: Package {dependent_package} depends on
+            {dependency_name}, currently installed at version
+            {version_used.__str__}. Future updates to
+            {dependent_package} will require {dependency_name} at
+            version {next_supported_version} or higher. Please ensure
+            that either (a) your Python environment doesn't pin the
+            version of {dependency_name}, so that updates to
+            {dependent_package} can require the higher version, or (b)
+            you manually update your Python environment to use at
+            least version {next_supported_version} of
+            {dependency_name}."""
+        )
+        logging.warning(
+            message_template.format(
+                dependent_package=dependent_package,
+                dependency_name=dependency_name,
+                next_supported_version=next_supported_version,
+                version_used=version_used,
+            ))
+
+def check_dependency_versions(dependent_package: str):
+    warn_deprecation_for_versions_less_than(dependent_package, "protobuf (google.protobuf)", "4.25.8")

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -52,7 +52,7 @@ def get_dependency_version(dependency_name: str) -> Optional[PackagingVersion]:
             version_string = pkg_resources.get_distribution(dependency_name).version
             return parse_version(version_string)
 
-    except:
+    except Exception:
         return None
 
 

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -110,7 +110,8 @@ def warn_deprecation_for_versions_less_than(
             dependent_distribution_package,
         ) = _get_distribution_and_import_packages(dependent_import_package)
         message_template = message_template or _flatten_message(
-            """DEPRECATION: Package {dependent_packages} depends on
+            """
+            DEPRECATION: Package {dependent_packages} depends on
             {dependency_packages}, currently installed at version
             {version_used.__str__}. Future updates to
             {dependent_packages} will require {dependency_packages} at
@@ -120,12 +121,15 @@ def warn_deprecation_for_versions_less_than(
             {dependent_packages} can require the higher version, or
             (b) you manually update your Python environment to use at
             least version {next_supported_version} of
-            {dependency_packages}."""
+            {dependency_packages}.
+            """
         )
         logging.warning(
             message_template.format(
                 dependent_import_package=dependent_import_package,
                 dependency_import_package=dependency_import_package,
+                dependency_packages=dependency_packages,
+                dependent_packages=dependent_packages,
                 next_supported_version=next_supported_version,
                 version_used=version_used,
             )

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -72,7 +72,7 @@ def get_dependency_version(
 
 
 def warn_deprecation_for_versions_less_than(
-    dependent_import_package: str,
+    consumer_import_package: str,
     dependency_import_package: str,
     minimum_fully_supported_version: str,
     recommended_version: Optional[str] = None,
@@ -84,12 +84,12 @@ def warn_deprecation_for_versions_less_than(
     `minimum_fully_supported_version`, this issues a warning using either a
     default `message_template` or one provided by the user. The
     default `message_template` informs the user that they will not receive
-    future updates for `dependent_import_package` if
+    future updates for `consumer_import_package` if
     `dependency_import_package` is somehow pinned to a version lower
     than `minimum_fully_supported_version`.
 
     Args:
-      dependent_import_package: The import name of the package that
+      consumer_import_package: The import name of the package that
         needs `dependency_import_package`.
       dependency_import_package: The import name of the dependency to check.
       minimum_fully_supported_version: The dependency_import_package version number
@@ -99,19 +99,19 @@ def warn_deprecation_for_versions_less_than(
       message_template: A custom default message template to replace
         the default. This `message_template` is treated as an
         f-string, where the following variables are defined:
-        `dependency_import_package`, `dependent_import_package` and
+        `dependency_import_package`, `consumer_import_package` and
         `dependency_distribution_package` and
-        `dependent_distribution_package` and `dependency_package`,
-        `dependent_package` , which contain the import packages, the
+        `consumer_distribution_package` and `dependency_package`,
+        `consumer_package` , which contain the import packages, the
         distribution packages, and pretty string with both the
         distribution and import packages for the dependency and the
-        dependent, respectively; and `minimum_fully_supported_version`,
+        consumer, respectively; and `minimum_fully_supported_version`,
         `version_used`, and `version_used_string`, which refer to supported
         and currently-used versions of the dependency.
 
     """
     if (
-        not dependent_import_package
+        not consumer_import_package
         or not dependency_import_package
         or not minimum_fully_supported_version
     ):  # pragma: NO COVER
@@ -125,24 +125,24 @@ def warn_deprecation_for_versions_less_than(
             dependency_distribution_package,
         ) = _get_distribution_and_import_packages(dependency_import_package)
         (
-            dependent_package,
-            dependent_distribution_package,
-        ) = _get_distribution_and_import_packages(dependent_import_package)
+            consumer_package,
+            consumer_distribution_package,
+        ) = _get_distribution_and_import_packages(consumer_import_package)
 
         recommendation = (
             " (we recommend {recommended_version})" if recommended_version else ""
         )
         message_template = message_template or _flatten_message(
             """
-            DEPRECATION: Package {dependent_package} depends on
+            DEPRECATION: Package {consumer_package} depends on
             {dependency_package}, currently installed at version
             {version_used_string}. Future updates to
-            {dependent_package} will require {dependency_package} at
+            {consumer_package} will require {dependency_package} at
             version {minimum_fully_supported_version} or
             higher{recommendation}. Please ensure that either (a) your
             Python environment doesn't pin the version of
             {dependency_package}, so that updates to
-            {dependent_package} can require the higher version, or (b)
+            {consumer_package} can require the higher version, or (b)
             you manually update your Python environment to use at
             least version {minimum_fully_supported_version} of
             {dependency_package}.
@@ -150,12 +150,12 @@ def warn_deprecation_for_versions_less_than(
         )
         warnings.warn(
             message_template.format(
-                dependent_import_package=dependent_import_package,
+                consumer_import_package=consumer_import_package,
                 dependency_import_package=dependency_import_package,
-                dependent_distribution_package=dependent_distribution_package,
+                consumer_distribution_package=consumer_distribution_package,
                 dependency_distribution_package=dependency_distribution_package,
                 dependency_package=dependency_package,
-                dependent_package=dependent_package,
+                consumer_package=consumer_package,
                 minimum_fully_supported_version=minimum_fully_supported_version,
                 recommendation=recommendation,
                 version_used=dependency_version.version,
@@ -165,7 +165,7 @@ def warn_deprecation_for_versions_less_than(
         )
 
 
-def check_dependency_versions(dependent_import_package: str):
+def check_dependency_versions(consumer_import_package: str):
     """Bundle checks for all package dependencies.
 
     This function can be called by all dependents of google.api_core,
@@ -173,10 +173,10 @@ def check_dependency_versions(dependent_import_package: str):
     dependencies. The dependencies to check should be updated here.
 
     Args:
-      dependent_import_package: The distribution name of the calling package, whose
+      consumer_import_package: The distribution name of the calling package, whose
         dependencies we're checking.
 
     """
     warn_deprecation_for_versions_less_than(
-        dependent_import_package, "google.protobuf", "4.25.8", recommended_version="6.x"
+        consumer_import_package, "google.protobuf", "4.25.8", recommended_version="6.x"
     )

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -117,7 +117,7 @@ def warn_deprecation_for_versions_less_than(
             """
             DEPRECATION: Package {dependent_package} depends on
             {dependency_package}, currently installed at version
-            {version_used.__str__}. Future updates to
+            {version_used.__str__()}. Future updates to
             {dependent_package} will require {dependency_package} at
             version {next_supported_version} or higher. Please ensure
             that either (a) your Python environment doesn't pin the

--- a/google/api_core/_python_package_support.py
+++ b/google/api_core/_python_package_support.py
@@ -22,7 +22,6 @@ from ._python_version_support import (
     _get_distribution_and_import_packages,
 )
 
-# It is a good practice to alias the Version class for clarity in type hints.
 from packaging.version import parse as parse_version, Version as PackagingVersion
 
 
@@ -72,7 +71,7 @@ def warn_deprecation_for_versions_less_than(
     `next_supported_version`, this issues a warning using either a
     default `message_template` or one provided by the user. The
     default `message_template` informs the user that they will not receive
-    future updates `dependent_import_package` if
+    future updates for `dependent_import_package` if
     `dependency_import_package` is somehow pinned to a version lower
     than `next_supported_version`.
 
@@ -80,16 +79,20 @@ def warn_deprecation_for_versions_less_than(
       dependent_import_package: The import name of the package that
         needs `dependency_import_package`.
       dependency_import_package: The import name of the dependency to check.
-      next_supported_version: The version number below which a deprecation
-        warning will be logged.
+      next_supported_version: The dependency_import_package version number
+        below which a deprecation warning will be logged.
       message_template: A custom default message template to replace
         the default. This `message_template` is treated as an
         f-string, where the following variables are defined:
         `dependency_import_package`, `dependent_import_package` and
-        `dependency_package`, `dependent_package`, which contain both the
-         import and distribution packages for the dependency and the dependent,
-         respectively; and `next_supported_version` and `version_used`, which
-         refer to supported and currently-used versions of the dependency.
+        `dependency_distribution_package` and
+        `dependent_distribution_package` and `dependency_package`,
+        `dependent_package` , which contain the import packages, the
+        distribution packages, and pretty string with both the
+        distribution and import packages for the dependency and the
+        dependent, respectively; and `next_supported_version` and
+        `version_used`, which refer to supported and currently-used
+        versions of the dependency.
 
     """
     if (
@@ -129,6 +132,8 @@ def warn_deprecation_for_versions_less_than(
             message_template.format(
                 dependent_import_package=dependent_import_package,
                 dependency_import_package=dependency_import_package,
+                dependent_distribution_package=dependent_distribution_package,
+                dependency_distribution_package=dependency_distribution_package,
                 dependency_package=dependency_package,
                 dependent_package=dependent_package,
                 next_supported_version=next_supported_version,

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -35,6 +35,7 @@ class PythonVersionStatus(enum.Enum):
 class VersionInfo(NamedTuple):
     """Hold release and support date information for a Python version."""
 
+    version: str
     python_beta: Optional[datetime.date]
     python_start: datetime.date
     python_eol: datetime.date
@@ -44,55 +45,67 @@ class VersionInfo(NamedTuple):
     dep_unpatchable_cve: Optional[datetime.date] = None  # unused
 
 
-PYTHON_VERSION_INFO: Dict[Tuple[int, int], VersionInfo] = {
+PYTHON_VERSIONS: list[VersionInfo] = [
     # Refer to https://devguide.python.org/versions/ and the PEPs linked therefrom.
-    (3, 7): VersionInfo(
+    VersionInfo(
+        version="3.7",
         python_beta=None,
         python_start=datetime.date(2018, 6, 27),
         python_eol=datetime.date(2023, 6, 27),
     ),
-    (3, 8): VersionInfo(
+    VersionInfo(
+        version="3.8",
         python_beta=None,
         python_start=datetime.date(2019, 10, 14),
         python_eol=datetime.date(2024, 10, 7),
     ),
-    (3, 9): VersionInfo(
+    VersionInfo(
+        version="3.9",
         python_beta=datetime.date(2020, 5, 18),
         python_start=datetime.date(2020, 10, 5),
-        python_eol=datetime.date(2025, 10, 5),  # TODO: specify day when announced
-        gapic_end=datetime.date(2025, 10, 5)
-        + datetime.timedelta(days=90),  # TODO: specify day when announced
+        python_eol=datetime.date(2025, 10, 5),
+        gapic_end=datetime.date(2025, 10, 5) + datetime.timedelta(days=90),
     ),
-    (3, 10): VersionInfo(
+    VersionInfo(
+        version="3.10",
         python_beta=datetime.date(2021, 5, 3),
         python_start=datetime.date(2021, 10, 4),
         python_eol=datetime.date(2026, 10, 4),  # TODO: specify day when announced
     ),
-    (3, 11): VersionInfo(
+    VersionInfo(
+        version="3.11",
         python_beta=datetime.date(2022, 5, 8),
         python_start=datetime.date(2022, 10, 24),
         python_eol=datetime.date(2027, 10, 24),  # TODO: specify day when announced
     ),
-    (3, 12): VersionInfo(
+    VersionInfo(
+        version="3.12",
         python_beta=datetime.date(2023, 5, 22),
         python_start=datetime.date(2023, 10, 2),
         python_eol=datetime.date(2028, 10, 2),  # TODO: specify day when announced
     ),
-    (3, 13): VersionInfo(
+    VersionInfo(
+        version="3.13",
         python_beta=datetime.date(2024, 5, 8),
         python_start=datetime.date(2024, 10, 7),
         python_eol=datetime.date(2029, 10, 7),  # TODO: specify day when announced
     ),
-    (3, 14): VersionInfo(
+    VersionInfo(
+        version="3.14",
         python_beta=datetime.date(2025, 5, 7),
         python_start=datetime.date(2025, 10, 7),
         python_eol=datetime.date(2030, 10, 7),  # TODO: specify day when announced
     ),
+]
+
+PYTHON_VERSION_INFO: Dict[Tuple[int, int], VersionInfo] = {
+    tuple(map(int, info.version.split("."))): info for info in PYTHON_VERSIONS
 }
 
+
 LOWEST_TRACKED_VERSION = min(PYTHON_VERSION_INFO.keys())
-FAKE_PAST_DATE = datetime.date(1970, 1, 1)
-FAKE_FUTURE_DATE = datetime.date(9000, 1, 1)
+FAKE_PAST_DATE = datetime.date.min + datetime.timedelta(days=900)
+FAKE_FUTURE_DATE = datetime.date.max - datetime.timedelta(days=900)
 DEPRECATION_WARNING_PERIOD = datetime.timedelta(days=365)
 EOL_GRACE_PERIOD = datetime.timedelta(weeks=1)
 
@@ -164,12 +177,14 @@ def check_python_version(
     if not version_info:
         if version_tuple < LOWEST_TRACKED_VERSION:
             version_info = VersionInfo(
+                version="0.0",
                 python_beta=FAKE_PAST_DATE,
                 python_start=FAKE_PAST_DATE,
                 python_eol=FAKE_PAST_DATE,
             )
         else:
             version_info = VersionInfo(
+                version="999.0",
                 python_beta=FAKE_FUTURE_DATE,
                 python_start=FAKE_FUTURE_DATE,
                 python_eol=FAKE_FUTURE_DATE,

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -19,7 +19,7 @@ import enum
 import warnings
 import sys
 import textwrap
-from typing import Any, NamedTuple, Optional, Dict, Tuple
+from typing import Any, List, NamedTuple, Optional, Dict, Tuple
 
 
 class PythonVersionStatus(enum.Enum):
@@ -64,7 +64,7 @@ class VersionInfo(NamedTuple):
     dep_unpatchable_cve: Optional[datetime.date] = None  # unused
 
 
-PYTHON_VERSIONS: list[VersionInfo] = [
+PYTHON_VERSIONS: List[VersionInfo] = [
     # Refer to https://devguide.python.org/versions/ and the PEPs linked therefrom.
     VersionInfo(
         version="3.7",

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -97,8 +97,9 @@ def _flatten_message(text: str) -> str:
     return textwrap.dedent(text).strip().replace("\n", " ")
 
 
-def check_python_version(package: Optional[str] = "this package",
-                         today: Optional[datetime.date] = None) -> PythonVersionStatus:
+def check_python_version(
+    package: Optional[str] = "this package", today: Optional[datetime.date] = None
+) -> PythonVersionStatus:
     """Check the running Python version and issue a support warning if needed.
 
     Args:

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -60,7 +60,8 @@ PYTHON_VERSION_INFO: Dict[Tuple[int, int], VersionInfo] = {
         python_beta=datetime.date(2020, 5, 18),
         python_start=datetime.date(2020, 10, 5),
         python_eol=datetime.date(2025, 10, 5),  # TODO: specify day when announced
-        gapic_end=datetime.date(2025, 10, 5) + datetime.timedelta(days=90),  # TODO: specify day when announced
+        gapic_end=datetime.date(2025, 10, 5)
+        + datetime.timedelta(days=90),  # TODO: specify day when announced
     ),
     (3, 10): VersionInfo(
         python_beta=datetime.date(2021, 5, 3),

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -185,11 +185,13 @@ def check_python_version(
 
     if gapic_end < today:
         message = _flatten_message(
-            f"""You are using a non-supported Python version
+            f"""
+            You are using a non-supported Python version
             ({py_version_str}).  Google will not post any further
             updates to {package_label}. We suggest you upgrade to the
             latest Python version, or at least Python
-            {min_python(today)}, and then update {package_label}. """
+            {min_python(today)}, and then update {package_label}.
+            """
         )
         logging.warning(message)
         return PythonVersionStatus.PYTHON_VERSION_UNSUPPORTED
@@ -197,24 +199,28 @@ def check_python_version(
     eol_date = version_info.python_eol + EOL_GRACE_PERIOD
     if eol_date <= today <= gapic_end:
         message = _flatten_message(
-            f"""You are using a Python version ({py_version_str})
+            f"""
+            You are using a Python version ({py_version_str})
             past its end of life. Google will update {package_label}
             with critical bug fixes on a best-effort basis, but not
             with any other fixes or features. We suggest you upgrade
             to the latest Python version, or at least Python
-            {min_python(today)}, and then update {package_label}."""
+            {min_python(today)}, and then update {package_label}.
+            """
         )
         logging.warning(message)
         return PythonVersionStatus.PYTHON_VERSION_EOL
 
     if gapic_deprecation <= today <= gapic_end:
         message = _flatten_message(
-            f"""You are using a Python version ({py_version_str}),
+            f"""
+            You are using a Python version ({py_version_str}),
             which Google will stop supporting in {package_label} when
             it reaches its end of life ({version_info.python_eol}). We
             suggest you upgrade to the latest Python version, or at
             least Python {min_python(version_info.python_eol)}, and
-            then update {package_label}."""
+            then update {package_label}.
+            """
         )
         logging.warning(message)
         return PythonVersionStatus.PYTHON_VERSION_DEPRECATED

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -25,6 +25,7 @@ from typing import Any, NamedTuple, Optional, Dict, Tuple
 class PythonVersionStatus(enum.Enum):
     """Represent the support status of a Python version."""
 
+    PYTHON_VERSION_STATUS_UNSPECIFIED = "PYTHON_VERSION_STATUS_UNSPECIFIED"
     PYTHON_VERSION_UNSUPPORTED = "PYTHON_VERSION_UNSUPPORTED"
     PYTHON_VERSION_EOL = "PYTHON_VERSION_EOL"
     PYTHON_VERSION_DEPRECATED = "PYTHON_VERSION_DEPRECATED"

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -117,9 +117,10 @@ PYTHON_VERSIONS: list[VersionInfo] = [
     ),
 ]
 
-PYTHON_VERSION_INFO: Dict[Tuple[int, int], VersionInfo] = {
-    tuple(map(int, info.version.split("."))): info for info in PYTHON_VERSIONS
-}
+PYTHON_VERSION_INFO: Dict[Tuple[int, int], VersionInfo] = {}
+for info in PYTHON_VERSIONS:
+    major, minor = map(int, info.version.split("."))
+    PYTHON_VERSION_INFO[(major, minor)] = info
 
 
 LOWEST_TRACKED_VERSION = min(PYTHON_VERSION_INFO.keys())

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -195,7 +195,7 @@ def check_python_version(
             {min_python(today)}, and then update {package_label}.
             """
         )
-        warnings.warn(message)
+        warnings.warn(message, FutureWarning)
         return PythonVersionStatus.PYTHON_VERSION_UNSUPPORTED
 
     eol_date = version_info.python_eol + EOL_GRACE_PERIOD
@@ -210,7 +210,7 @@ def check_python_version(
             {min_python(today)}, and then update {package_label}.
             """
         )
-        warnings.warn(message)
+        warnings.warn(message, FutureWarning)
         return PythonVersionStatus.PYTHON_VERSION_EOL
 
     if gapic_deprecation <= today <= gapic_end:
@@ -224,7 +224,7 @@ def check_python_version(
             then update {package_label}.
             """
         )
-        warnings.warn(message)
+        warnings.warn(message, FutureWarning)
         return PythonVersionStatus.PYTHON_VERSION_DEPRECATED
 
     return PythonVersionStatus.PYTHON_VERSION_SUPPORTED

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -117,7 +117,7 @@ else:
             module_to_distributions = metadata.packages_distributions()
 
             # Check if the module is found in the mapping
-            if module_name in module_to_distributions:
+            if module_name in module_to_distributions:  # pragma: NO COVER
                 # The value is a list of distribution names, take the first one
                 return module_to_distributions[module_name][0]
             else:

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -60,6 +60,7 @@ PYTHON_VERSION_INFO: Dict[Tuple[int, int], VersionInfo] = {
         python_beta=datetime.date(2020, 5, 18),
         python_start=datetime.date(2020, 10, 5),
         python_eol=datetime.date(2025, 10, 5),  # TODO: specify day when announced
+        gapic_end=datetime.date(2025, 10, 5) + datetime.timedelta(days=90),  # TODO: specify day when announced
     ),
     (3, 10): VersionInfo(
         python_beta=datetime.date(2021, 5, 3),
@@ -155,7 +156,7 @@ def check_python_version(
 
     python_version = sys.version_info
     version_tuple = (python_version.major, python_version.minor)
-    py_version_str = f"{python_version.major}.{python_version.minor}"
+    py_version_str = sys.version.split()[0]
 
     version_info = PYTHON_VERSION_INFO.get(version_tuple)
 
@@ -188,11 +189,11 @@ def check_python_version(
     if gapic_end < today:
         message = _flatten_message(
             f"""
-            You are using a non-supported Python version
-            ({py_version_str}).  Google will not post any further
-            updates to {package_label}. Please upgrade to the
-            latest Python version, or at least Python
-            {min_python(today)}, and then update {package_label}.
+            You are using a non-supported Python version ({py_version_str}).
+            Google will not post any further updates to {package_label}
+            supporting this Python version. Please upgrade to the latest Python
+            version, or at least Python {min_python(today)}, and then update
+            {package_label}.
             """
         )
         warnings.warn(message, FutureWarning)
@@ -216,12 +217,12 @@ def check_python_version(
     if gapic_deprecation <= today <= gapic_end:
         message = _flatten_message(
             f"""
-            You are using a Python version ({py_version_str})
-            which Google will stop supporting in {package_label} when
-            it reaches its end of life ({version_info.python_eol}). Please
-            upgrade to the latest Python version, or at
-            least Python {min_python(version_info.python_eol)}, and
-            then update {package_label}.
+            You are using a Python version ({py_version_str}) which Google will
+            stop supporting in new releases of {package_label} once it reaches
+            its end of life ({version_info.python_eol}). Please upgrade to the
+            latest Python version, or at least Python
+            {min_python(version_info.python_eol)}, to continue receiving updates
+            for {package_label} past that date.
             """
         )
         warnings.warn(message, FutureWarning)

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -100,10 +100,10 @@ def _flatten_message(text: str) -> str:
     return textwrap.dedent(text).strip().replace("\n", " ")
 
 
-# TODO: Remove once we no longer support Python3.7
+# TODO: Remove once we no longer support Python 3.7
 if sys.version_info < (3, 8):
 
-    def _get_pypi_package_name(module_name):
+    def _get_pypi_package_name(module_name):  # pragma: NO COVER
         """Determine the PyPI package name for a given module name."""
         return None
 

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -221,7 +221,7 @@ def check_python_version(
         for version, info in sorted(PYTHON_VERSION_INFO.items()):
             if info.python_start <= date < info.python_eol:
                 return f"{version[0]}.{version[1]}"
-        return "at a supported version"
+        return "at a currently supported version [https://devguide.python.org/versions]"
 
     if gapic_end < today:
         message = _flatten_message(

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -1,0 +1,186 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Code to check Python versions supported by Google Cloud Client Libraries."""
+
+import datetime
+import enum
+import logging
+import sys
+import textwrap
+from typing import NamedTuple, Optional, Dict, Tuple
+
+
+class PythonVersionStatus(enum.Enum):
+    """Represent the support status of a Python version."""
+
+    PYTHON_VERSION_UNSUPPORTED = "PYTHON_VERSION_UNSUPPORTED"
+    PYTHON_VERSION_EOL = "PYTHON_VERSION_EOL"
+    PYTHON_VERSION_DEPRECATED = "PYTHON_VERSION_DEPRECATED"
+    PYTHON_VERSION_SUPPORTED = "PYTHON_VERSION_SUPPORTED"
+
+
+class VersionInfo(NamedTuple):
+    """Hold release and support date information for a Python version."""
+
+    python_beta: Optional[datetime.date]
+    python_start: datetime.date
+    python_eol: datetime.date
+    gapic_start: Optional[datetime.date] = None
+    gapic_deprecation: Optional[datetime.date] = None
+    gapic_end: Optional[datetime.date] = None
+    dep_unpatchable_cve: Optional[datetime.date] = None
+
+
+PYTHON_VERSION_INFO: Dict[Tuple[int, int], VersionInfo] = {
+    # Refer to https://devguide.python.org/versions/ and the PEPs linked therefrom.
+    (3, 7): VersionInfo(
+        python_beta=None,
+        python_start=datetime.date(2018, 6, 27),
+        python_eol=datetime.date(2023, 6, 27),
+    ),
+    (3, 8): VersionInfo(
+        python_beta=None,
+        python_start=datetime.date(2019, 10, 14),
+        python_eol=datetime.date(2024, 10, 7),
+    ),
+    (3, 9): VersionInfo(
+        python_beta=datetime.date(2020, 5, 18),
+        python_start=datetime.date(2020, 10, 5),
+        python_eol=datetime.date(2025, 10, 5),  # TODO: specify day when announced
+    ),
+    (3, 10): VersionInfo(
+        python_beta=datetime.date(2021, 5, 3),
+        python_start=datetime.date(2021, 10, 4),
+        python_eol=datetime.date(2026, 10, 4),  # TODO: specify day when announced
+    ),
+    (3, 11): VersionInfo(
+        python_beta=datetime.date(2022, 5, 8),
+        python_start=datetime.date(2022, 10, 24),
+        python_eol=datetime.date(2027, 10, 24),  # TODO: specify day when announced
+    ),
+    (3, 12): VersionInfo(
+        python_beta=datetime.date(2023, 5, 22),
+        python_start=datetime.date(2023, 10, 2),
+        python_eol=datetime.date(2028, 10, 2),  # TODO: specify day when announced
+    ),
+    (3, 13): VersionInfo(
+        python_beta=datetime.date(2024, 5, 8),
+        python_start=datetime.date(2024, 10, 7),
+        python_eol=datetime.date(2029, 10, 7),  # TODO: specify day when announced
+    ),
+    (3, 14): VersionInfo(
+        python_beta=datetime.date(2025, 5, 7),
+        python_start=datetime.date(2025, 10, 7),
+        python_eol=datetime.date(2030, 10, 7),  # TODO: specify day when announced
+    ),
+}
+
+LOWEST_TRACKED_VERSION = min(PYTHON_VERSION_INFO.keys())
+FAKE_PAST_DATE = datetime.date(1970, 1, 1)
+FAKE_FUTURE_DATE = datetime.date(9000, 1, 1)
+
+
+def _flatten_message(text: str) -> str:
+    """Dedent a multi-line string and flattens it into a single line."""
+    return textwrap.dedent(text).strip().replace("\n", " ")
+
+
+def check_python_version(today: Optional[datetime.date] = None) -> PythonVersionStatus:
+    """Check the running Python version and issue a support warning if needed.
+
+    Args:
+        today: The date to check against. Defaults to the current date.
+
+    Returns:
+        The support status of the current Python version.
+    """
+    today = today or datetime.date.today()
+
+    python_version = sys.version_info
+    version_tuple = (python_version.major, python_version.minor)
+    py_version_str = f"{python_version.major}.{python_version.minor}"
+
+    version_info = PYTHON_VERSION_INFO.get(version_tuple)
+
+    if not version_info:
+        if version_tuple < LOWEST_TRACKED_VERSION:
+            version_info = VersionInfo(
+                python_beta=FAKE_PAST_DATE,
+                python_start=FAKE_PAST_DATE,
+                python_eol=FAKE_PAST_DATE,
+            )
+        else:
+            version_info = VersionInfo(
+                python_beta=FAKE_FUTURE_DATE,
+                python_start=FAKE_FUTURE_DATE,
+                python_eol=FAKE_FUTURE_DATE,
+            )
+
+    gapic_deprecation = version_info.gapic_deprecation or (
+        version_info.python_eol - datetime.timedelta(days=365)
+    )
+    gapic_end = version_info.gapic_end or (
+        version_info.python_eol + datetime.timedelta(weeks=1)
+    )
+
+    def min_python(date: datetime.date) -> str:
+        """Find the minimum supported Python version for a given date."""
+        for version, info in sorted(PYTHON_VERSION_INFO.items()):
+            if info.python_start <= date < info.python_eol:
+                return f"{version[0]}.{version[1]}"
+        return "at a supported version"
+
+    if gapic_end < today:
+        message = _flatten_message(
+            f"""
+            You are using a non-supported Python version ({py_version_str}).
+            You will receive no updates to this client library. We suggest
+            you upgrade to the latest Python version, or at least Python
+            {min_python(today)}, and then update this library.
+            """
+        )
+        logging.warning(message)
+        return PythonVersionStatus.PYTHON_VERSION_UNSUPPORTED
+
+    eol_date = version_info.python_eol + datetime.timedelta(weeks=1)
+    if eol_date <= today <= gapic_end:
+        message = _flatten_message(
+            f"""
+            You are using a Python version ({py_version_str}) past its end
+            of life. This client library will continue receiving critical
+            bug fixes on a best-effort basis, but not any other fixes or
+            features. We suggest you upgrade to the latest Python version,
+            or at least Python {min_python(today)}, and then update this
+            library.
+            """
+        )
+        logging.warning(message)
+        return PythonVersionStatus.PYTHON_VERSION_EOL
+
+    if gapic_deprecation <= today <= gapic_end:
+        message = _flatten_message(
+            f"""
+            You are using a Python version ({py_version_str}), which new
+            releases of this client library will stop supporting when it
+            reaches its end of life ({version_info.python_eol}). We
+            suggest you upgrade to the latest Python version, or at least
+            Python {min_python(version_info.python_eol)}, and then update
+            this library.
+            """
+        )
+        logging.warning(message)
+        return PythonVersionStatus.PYTHON_VERSION_DEPRECATED
+
+    return PythonVersionStatus.PYTHON_VERSION_SUPPORTED

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -123,8 +123,20 @@ PYTHON_VERSION_INFO: Dict[Tuple[int, int], VersionInfo] = {
 
 
 LOWEST_TRACKED_VERSION = min(PYTHON_VERSION_INFO.keys())
-FAKE_PAST_DATE = datetime.date.min + datetime.timedelta(days=900)
-FAKE_FUTURE_DATE = datetime.date.max - datetime.timedelta(days=900)
+_FAKE_PAST_DATE = datetime.date.min + datetime.timedelta(days=900)
+_FAKE_PAST_VERSION = VersionInfo(
+    version="0.0",
+    python_beta=_FAKE_PAST_DATE,
+    python_start=_FAKE_PAST_DATE,
+    python_eol=_FAKE_PAST_DATE,
+)
+_FAKE_FUTURE_DATE = datetime.date.max - datetime.timedelta(days=900)
+_FAKE_FUTURE_VERSION = VersionInfo(
+    version="999.0",
+    python_beta=_FAKE_FUTURE_DATE,
+    python_start=_FAKE_FUTURE_DATE,
+    python_eol=_FAKE_FUTURE_DATE,
+)
 DEPRECATION_WARNING_PERIOD = datetime.timedelta(days=365)
 EOL_GRACE_PERIOD = datetime.timedelta(weeks=1)
 
@@ -195,19 +207,9 @@ def check_python_version(
 
     if not version_info:
         if version_tuple < LOWEST_TRACKED_VERSION:
-            version_info = VersionInfo(
-                version="0.0",
-                python_beta=FAKE_PAST_DATE,
-                python_start=FAKE_PAST_DATE,
-                python_eol=FAKE_PAST_DATE,
-            )
+            version_info = _FAKE_PAST_VERSION
         else:
-            version_info = VersionInfo(
-                version="999.0",
-                python_beta=FAKE_FUTURE_DATE,
-                python_start=FAKE_FUTURE_DATE,
-                python_eol=FAKE_FUTURE_DATE,
-            )
+            version_info = _FAKE_FUTURE_VERSION
 
     gapic_deprecation = version_info.gapic_deprecation or (
         version_info.python_eol - DEPRECATION_WARNING_PERIOD

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -23,13 +23,32 @@ from typing import Any, NamedTuple, Optional, Dict, Tuple
 
 
 class PythonVersionStatus(enum.Enum):
-    """Represent the support status of a Python version."""
+    """Support status of a Python version in this client library artifact release.
+
+    "Support", in this context, means that this release of a client library
+    artifact is configured to run on the currently configured version of
+    Python.
+    """
 
     PYTHON_VERSION_STATUS_UNSPECIFIED = "PYTHON_VERSION_STATUS_UNSPECIFIED"
-    PYTHON_VERSION_UNSUPPORTED = "PYTHON_VERSION_UNSUPPORTED"
-    PYTHON_VERSION_EOL = "PYTHON_VERSION_EOL"
-    PYTHON_VERSION_DEPRECATED = "PYTHON_VERSION_DEPRECATED"
+
     PYTHON_VERSION_SUPPORTED = "PYTHON_VERSION_SUPPORTED"
+    """This Python version is fully supported, so the artifact running on this
+    version will have all features and bug fixes."""
+
+    PYTHON_VERSION_DEPRECATED = "PYTHON_VERSION_DEPRECATED"
+    """This Python version is still supported, but support will end within a
+    year. At that time, there will be no more releases for this artifact
+    running under this Python version."""
+
+    PYTHON_VERSION_EOL = "PYTHON_VERSION_EOL"
+    """This Python version has reached its end of life in the Python community
+    (see https://devguide.python.org/versions/), and this artifact will cease
+    supporting this Python version within the next few releases."""
+
+    PYTHON_VERSION_UNSUPPORTED = "PYTHON_VERSION_UNSUPPORTED"
+    """This release of the client library artifact may not be the latest, since
+    current releases no longer support this Python version."""
 
 
 class VersionInfo(NamedTuple):

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -37,10 +37,10 @@ class VersionInfo(NamedTuple):
     python_beta: Optional[datetime.date]
     python_start: datetime.date
     python_eol: datetime.date
-    gapic_start: Optional[datetime.date] = None
+    gapic_start: Optional[datetime.date] = None  # unused
     gapic_deprecation: Optional[datetime.date] = None
     gapic_end: Optional[datetime.date] = None
-    dep_unpatchable_cve: Optional[datetime.date] = None
+    dep_unpatchable_cve: Optional[datetime.date] = None  # unused
 
 
 PYTHON_VERSION_INFO: Dict[Tuple[int, int], VersionInfo] = {
@@ -97,7 +97,8 @@ def _flatten_message(text: str) -> str:
     return textwrap.dedent(text).strip().replace("\n", " ")
 
 
-def check_python_version(today: Optional[datetime.date] = None) -> PythonVersionStatus:
+def check_python_version(package: Optional[str] = "this package",
+                         today: Optional[datetime.date] = None) -> PythonVersionStatus:
     """Check the running Python version and issue a support warning if needed.
 
     Args:
@@ -146,9 +147,9 @@ def check_python_version(today: Optional[datetime.date] = None) -> PythonVersion
         message = _flatten_message(
             f"""
             You are using a non-supported Python version ({py_version_str}).
-            You will receive no updates to this client library. We suggest
+            Google will not post any further updates to {package}. We suggest
             you upgrade to the latest Python version, or at least Python
-            {min_python(today)}, and then update this library.
+            {min_python(today)}, and then update {package}.
             """
         )
         logging.warning(message)
@@ -159,11 +160,10 @@ def check_python_version(today: Optional[datetime.date] = None) -> PythonVersion
         message = _flatten_message(
             f"""
             You are using a Python version ({py_version_str}) past its end
-            of life. This client library will continue receiving critical
-            bug fixes on a best-effort basis, but not any other fixes or
+            of life. Google will update {package} with critical
+            bug fixes on a best-effort basis, but not with any other fixes or
             features. We suggest you upgrade to the latest Python version,
-            or at least Python {min_python(today)}, and then update this
-            library.
+            or at least Python {min_python(today)}, and then update {package}.
             """
         )
         logging.warning(message)
@@ -172,12 +172,12 @@ def check_python_version(today: Optional[datetime.date] = None) -> PythonVersion
     if gapic_deprecation <= today <= gapic_end:
         message = _flatten_message(
             f"""
-            You are using a Python version ({py_version_str}), which new
-            releases of this client library will stop supporting when it
+            You are using a Python version ({py_version_str}),
+            which Google will stop supporting in {package} when it
             reaches its end of life ({version_info.python_eol}). We
-            suggest you upgrade to the latest Python version, or at least
-            Python {min_python(version_info.python_eol)}, and then update
-            this library.
+            suggest you upgrade to the latest Python version, or at
+            least Python {min_python(version_info.python_eol)}, and
+            then update {package}.
             """
         )
         logging.warning(message)

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -19,7 +19,7 @@ import enum
 import logging
 import sys
 import textwrap
-from typing import NamedTuple, Optional, Dict, Tuple
+from typing import Any, NamedTuple, Optional, Dict, Tuple
 
 
 class PythonVersionStatus(enum.Enum):
@@ -126,7 +126,7 @@ else:
             return None
 
 
-def _get_distribution_and_import_packages(import_package: str) -> Optional[str]:
+def _get_distribution_and_import_packages(import_package: str) -> Tuple[str, Any]:
     """Return a pretty string with distribution & import package names."""
     distribution_package = _get_pypi_package_name(import_package)
     dependency_distribution_and_import_packages = (
@@ -138,7 +138,7 @@ def _get_distribution_and_import_packages(import_package: str) -> Optional[str]:
 
 
 def check_python_version(
-    package: Optional[str] = "this package", today: Optional[datetime.date] = None
+    package: str = "this package", today: Optional[datetime.date] = None
 ) -> PythonVersionStatus:
     """Check the running Python version and issue a support warning if needed.
 
@@ -188,7 +188,7 @@ def check_python_version(
             f"""
             You are using a non-supported Python version
             ({py_version_str}).  Google will not post any further
-            updates to {package_label}. We suggest you upgrade to the
+            updates to {package_label}. Please upgrade to the
             latest Python version, or at least Python
             {min_python(today)}, and then update {package_label}.
             """
@@ -203,7 +203,7 @@ def check_python_version(
             You are using a Python version ({py_version_str})
             past its end of life. Google will update {package_label}
             with critical bug fixes on a best-effort basis, but not
-            with any other fixes or features. We suggest you upgrade
+            with any other fixes or features. Please upgrade
             to the latest Python version, or at least Python
             {min_python(today)}, and then update {package_label}.
             """
@@ -214,10 +214,10 @@ def check_python_version(
     if gapic_deprecation <= today <= gapic_end:
         message = _flatten_message(
             f"""
-            You are using a Python version ({py_version_str}),
+            You are using a Python version ({py_version_str})
             which Google will stop supporting in {package_label} when
-            it reaches its end of life ({version_info.python_eol}). We
-            suggest you upgrade to the latest Python version, or at
+            it reaches its end of life ({version_info.python_eol}). Please
+            upgrade to the latest Python version, or at
             least Python {min_python(version_info.python_eol)}, and
             then update {package_label}.
             """

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -96,11 +96,12 @@ EOL_GRACE_PERIOD = datetime.timedelta(weeks=1)
 
 
 def _flatten_message(text: str) -> str:
-    """Dedent a multi-line string and flattens it into a single line."""
+    """Dedent a multi-line string and flatten it into a single line."""
     return textwrap.dedent(text).strip().replace("\n", " ")
 
 
-# TODO: Remove once we no longer support Python 3.7
+# TODO(https://github.com/googleapis/python-api-core/issues/835): Remove once we
+# no longer support Python 3.7
 if sys.version_info < (3, 8):
 
     def _get_pypi_package_name(module_name):  # pragma: NO COVER

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -90,6 +90,8 @@ PYTHON_VERSION_INFO: Dict[Tuple[int, int], VersionInfo] = {
 LOWEST_TRACKED_VERSION = min(PYTHON_VERSION_INFO.keys())
 FAKE_PAST_DATE = datetime.date(1970, 1, 1)
 FAKE_FUTURE_DATE = datetime.date(9000, 1, 1)
+DEPRECATION_WARNING_PERIOD = datetime.timedelta(days=365)
+EOL_GRACE_PERIOD = datetime.timedelta(weeks=1)
 
 
 def _flatten_message(text: str) -> str:
@@ -131,10 +133,10 @@ def check_python_version(
             )
 
     gapic_deprecation = version_info.gapic_deprecation or (
-        version_info.python_eol - datetime.timedelta(days=365)
+        version_info.python_eol - DEPRECATION_WARNING_PERIOD
     )
     gapic_end = version_info.gapic_end or (
-        version_info.python_eol + datetime.timedelta(weeks=1)
+        version_info.python_eol + EOL_GRACE_PERIOD
     )
 
     def min_python(date: datetime.date) -> str:
@@ -156,7 +158,7 @@ def check_python_version(
         logging.warning(message)
         return PythonVersionStatus.PYTHON_VERSION_UNSUPPORTED
 
-    eol_date = version_info.python_eol + datetime.timedelta(weeks=1)
+    eol_date = version_info.python_eol + EOL_GRACE_PERIOD
     if eol_date <= today <= gapic_end:
         message = _flatten_message(
             f"""

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -144,7 +144,7 @@ EOL_GRACE_PERIOD = datetime.timedelta(weeks=1)
 
 def _flatten_message(text: str) -> str:
     """Dedent a multi-line string and flatten it into a single line."""
-    return textwrap.dedent(text).strip().replace("\n", " ")
+    return " ".join(textwrap.dedent(text).strip().split())
 
 
 # TODO(https://github.com/googleapis/python-api-core/issues/835): Remove once we

--- a/google/api_core/_python_version_support.py
+++ b/google/api_core/_python_version_support.py
@@ -16,7 +16,7 @@
 
 import datetime
 import enum
-import logging
+import warnings
 import sys
 import textwrap
 from typing import Any, NamedTuple, Optional, Dict, Tuple
@@ -195,7 +195,7 @@ def check_python_version(
             {min_python(today)}, and then update {package_label}.
             """
         )
-        logging.warning(message)
+        warnings.warn(message)
         return PythonVersionStatus.PYTHON_VERSION_UNSUPPORTED
 
     eol_date = version_info.python_eol + EOL_GRACE_PERIOD
@@ -210,7 +210,7 @@ def check_python_version(
             {min_python(today)}, and then update {package_label}.
             """
         )
-        logging.warning(message)
+        warnings.warn(message)
         return PythonVersionStatus.PYTHON_VERSION_EOL
 
     if gapic_deprecation <= today <= gapic_end:
@@ -224,7 +224,7 @@ def check_python_version(
             then update {package_label}.
             """
         )
-        logging.warning(message)
+        warnings.warn(message)
         return PythonVersionStatus.PYTHON_VERSION_DEPRECATED
 
     return PythonVersionStatus.PYTHON_VERSION_SUPPORTED

--- a/tests/asyncio/test_operation_async.py
+++ b/tests/asyncio/test_operation_async.py
@@ -83,7 +83,6 @@ async def test_constructor():
     assert future.metadata is None
     assert await future.running()
 
-
 @pytest.mark.asyncio
 async def test_metadata():
     expected_metadata = struct_pb2.Struct()

--- a/tests/asyncio/test_operation_async.py
+++ b/tests/asyncio/test_operation_async.py
@@ -83,6 +83,7 @@ async def test_constructor():
     assert future.metadata is None
     assert await future.running()
 
+
 @pytest.mark.asyncio
 async def test_metadata():
     expected_metadata = struct_pb2.Struct()

--- a/tests/unit/gapic/test_method.py
+++ b/tests/unit/gapic/test_method.py
@@ -189,7 +189,7 @@ def test_wrap_method_with_overriding_retry_timeout_compression(unused_sleep):
     method.assert_called_with(
         timeout=specified_timeout,
         compression=grpc.Compression.Deflate,
-        metadata=mock.ANY
+        metadata=mock.ANY,
     )
 
 

--- a/tests/unit/gapic/test_method.py
+++ b/tests/unit/gapic/test_method.py
@@ -177,17 +177,16 @@ def test_wrap_method_with_overriding_retry_timeout_compression(unused_sleep):
         method, default_retry, default_timeout, default_compression
     )
 
-    specified_timeout = 22.0
     result = wrapped_method(
         retry=retry.Retry(retry.if_exception_type(exceptions.NotFound)),
-        timeout=timeout.ConstantTimeout(specified_timeout),
+        timeout=timeout.ConstantTimeout(22),
         compression=grpc.Compression.Deflate,
     )
 
     assert result == 42
     assert method.call_count == 2
     method.assert_called_with(
-        timeout=specified_timeout,
+        timeout=22,
         compression=grpc.Compression.Deflate,
         metadata=mock.ANY,
     )
@@ -201,8 +200,7 @@ def test_wrap_method_with_overriding_timeout_as_a_number():
         method, default_retry, default_timeout
     )
 
-    specified_timeout = 22.0
-    result = wrapped_method(timeout=specified_timeout)
+    result = wrapped_method(timeout=22)
 
     assert result == 42
 

--- a/tests/unit/gapic/test_method.py
+++ b/tests/unit/gapic/test_method.py
@@ -198,7 +198,8 @@ def test_wrap_method_with_overriding_timeout_as_a_number():
         method, default_retry, default_timeout
     )
 
-    result = wrapped_method(timeout=22)
+    specified_timeout = 22
+    result = wrapped_method(timeout=specified_timeout)
 
     assert result == 42
 

--- a/tests/unit/gapic/test_method.py
+++ b/tests/unit/gapic/test_method.py
@@ -177,7 +177,7 @@ def test_wrap_method_with_overriding_retry_timeout_compression(unused_sleep):
         method, default_retry, default_timeout, default_compression
     )
 
-    specified_timeout = 22
+    specified_timeout = 22.0
     result = wrapped_method(
         retry=retry.Retry(retry.if_exception_type(exceptions.NotFound)),
         timeout=timeout.ConstantTimeout(specified_timeout),
@@ -201,7 +201,7 @@ def test_wrap_method_with_overriding_timeout_as_a_number():
         method, default_retry, default_timeout
     )
 
-    specified_timeout = 22
+    specified_timeout = 22.0
     result = wrapped_method(timeout=specified_timeout)
 
     assert result == 42

--- a/tests/unit/gapic/test_method.py
+++ b/tests/unit/gapic/test_method.py
@@ -177,16 +177,19 @@ def test_wrap_method_with_overriding_retry_timeout_compression(unused_sleep):
         method, default_retry, default_timeout, default_compression
     )
 
+    specified_timeout = 22
     result = wrapped_method(
         retry=retry.Retry(retry.if_exception_type(exceptions.NotFound)),
-        timeout=timeout.ConstantTimeout(22),
+        timeout=timeout.ConstantTimeout(specified_timeout),
         compression=grpc.Compression.Deflate,
     )
 
     assert result == 42
     assert method.call_count == 2
     method.assert_called_with(
-        timeout=22, compression=grpc.Compression.Deflate, metadata=mock.ANY
+        timeout=specified_timeout,
+        compression=grpc.Compression.Deflate,
+        metadata=mock.ANY
     )
 
 

--- a/tests/unit/test_bidi.py
+++ b/tests/unit/test_bidi.py
@@ -828,11 +828,13 @@ class TestBackgroundConsumer(object):
         bidi_rpc._start_rpc.side_effect = expected_exception
 
         consumer = bidi.BackgroundConsumer(bidi_rpc, on_response=None)
+
+        consumer.start()
+
         # Wait for the consumer's thread to exit.
         while consumer.is_active:
             pass
 
-        consumer.start()
         assert callback.call_args.args[0] == grpc.StatusCode.INVALID_ARGUMENT
 
     def test_consumer_expected_error(self, caplog):

--- a/tests/unit/test_bidi.py
+++ b/tests/unit/test_bidi.py
@@ -828,6 +828,10 @@ class TestBackgroundConsumer(object):
         bidi_rpc._start_rpc.side_effect = expected_exception
 
         consumer = bidi.BackgroundConsumer(bidi_rpc, on_response=None)
+        # Wait for the consumer's thread to exit.
+        while consumer.is_active:
+            pass
+
         consumer.start()
         assert callback.call_args.args[0] == grpc.StatusCode.INVALID_ARGUMENT
 

--- a/tests/unit/test_bidi.py
+++ b/tests/unit/test_bidi.py
@@ -833,7 +833,7 @@ class TestBackgroundConsumer(object):
 
         # Wait for the consumer's thread to exit.
         while consumer.is_active:
-            pass
+            pass  # pragma: NO COVER
 
         assert callback.call_args.args[0] == grpc.StatusCode.INVALID_ARGUMENT
 

--- a/tests/unit/test_python_package_support.py
+++ b/tests/unit/test_python_package_support.py
@@ -105,7 +105,7 @@ def test_warn_deprecation_for_versions_less_than(
         ("my-package (my.package)", "my-package"),
     ]
     mock_get_version.return_value = parse_version("1.0.0")
-    template = "Custom warning for {dependency_packages} used by {dependent_packages}."
+    template = "Custom warning for {dependency_package} used by {dependent_package}."
     warn_deprecation_for_versions_less_than(
         "my.package", "dep.package", "2.0.0", message_template=template
     )

--- a/tests/unit/test_python_package_support.py
+++ b/tests/unit/test_python_package_support.py
@@ -1,0 +1,99 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+from packaging.version import parse as parse_version
+
+from google.api_core._python_package_support import (
+    get_dependency_version,
+    warn_deprecation_for_versions_less_than,
+)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
+@patch("importlib.metadata.version")
+def test_get_dependency_version_py38_plus(mock_version):
+    """Test get_dependency_version on Python 3.8+."""
+    mock_version.return_value = "1.2.3"
+    assert get_dependency_version("some-package") == parse_version("1.2.3")
+    mock_version.assert_called_once_with("some-package")
+
+    # Test package not found
+    mock_version.side_effect = ImportError
+    assert get_dependency_version("not-a-package") is None
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 8), reason="requires python3.7")
+@patch("pkg_resources.get_distribution")
+def test_get_dependency_version_py37(mock_get_distribution):
+    """Test get_dependency_version on Python 3.7."""
+    mock_dist = MagicMock()
+    mock_dist.version = "4.5.6"
+    mock_get_distribution.return_value = mock_dist
+    assert get_dependency_version("another-package") == parse_version("4.5.6")
+    mock_get_distribution.assert_called_once_with("another-package")
+
+    # Test package not found
+    mock_get_distribution.side_effect = Exception  # pkg_resources has its own exception types
+    assert get_dependency_version("not-a-package") is None
+
+
+@patch("google.api_core._python_package_support.get_dependency_version")
+@patch("google.api_core._python_package_support.logging.warning")
+def test_warn_deprecation_for_versions_less_than(mock_log_warning, mock_get_version):
+    """Test the deprecation warning logic."""
+    # Case 1: Installed version is less than required, should warn.
+    mock_get_version.return_value = parse_version("1.0.0")
+    warn_deprecation_for_versions_less_than(
+        "my-package", "dep-package", "2.0.0"
+    )
+    mock_log_warning.assert_called_once()
+    assert "DEPRECATION: Package my-package depends on dep-package" in mock_log_warning.call_args[0][0]
+
+    # Case 2: Installed version is equal to required, should not warn.
+    mock_log_warning.reset_mock()
+    mock_get_version.return_value = parse_version("2.0.0")
+    warn_deprecation_for_versions_less_than(
+        "my-package", "dep-package", "2.0.0"
+    )
+    mock_log_warning.assert_not_called()
+
+    # Case 3: Installed version is greater than required, should not warn.
+    mock_log_warning.reset_mock()
+    mock_get_version.return_value = parse_version("3.0.0")
+    warn_deprecation_for_versions_less_than(
+        "my-package", "dep-package", "2.0.0"
+    )
+    mock_log_warning.assert_not_called()
+
+    # Case 4: Dependency not found, should not warn.
+    mock_log_warning.reset_mock()
+    mock_get_version.return_value = None
+    warn_deprecation_for_versions_less_than(
+        "my-package", "dep-package", "2.0.0"
+    )
+    mock_log_warning.assert_not_called()
+
+    # Case 5: Custom message template.
+    mock_log_warning.reset_mock()
+    mock_get_version.return_value = parse_version("1.0.0")
+    template = "Custom warning for {dependency_name} used by {dependent_package}."
+    warn_deprecation_for_versions_less_than(
+        "my-package", "dep-package", "2.0.0", message_template=template
+    )
+    mock_log_warning.assert_called_once()
+    assert "Custom warning for dep-package used by my-package." in mock_log_warning.call_args[0][0]

--- a/tests/unit/test_python_package_support.py
+++ b/tests/unit/test_python_package_support.py
@@ -54,46 +54,63 @@ def test_get_dependency_version_py37(mock_get_distribution):
     assert get_dependency_version("not-a-package") is None
 
 
+@patch("google.api_core._python_package_support._get_distribution_and_import_packages")
 @patch("google.api_core._python_package_support.get_dependency_version")
 @patch("google.api_core._python_package_support.logging.warning")
-def test_warn_deprecation_for_versions_less_than(mock_log_warning, mock_get_version):
+def test_warn_deprecation_for_versions_less_than(
+    mock_log_warning, mock_get_version, mock_get_packages
+):
     """Test the deprecation warning logic."""
+    # Mock the helper function to return predictable package strings
+    mock_get_packages.side_effect = [
+        ("dep-package (dep.package)", "dep-package"),
+        ("my-package (my.package)", "my-package"),
+    ]
+
     # Case 1: Installed version is less than required, should warn.
     mock_get_version.return_value = parse_version("1.0.0")
-    warn_deprecation_for_versions_less_than("my-package", "dep-package", "2.0.0")
+    warn_deprecation_for_versions_less_than("my.package", "dep.package", "2.0.0")
     mock_log_warning.assert_called_once()
     assert (
-        "DEPRECATION: Package my-package depends on dep-package"
+        "DEPRECATION: Package my-package (my.package) depends on dep-package (dep.package)"
         in mock_log_warning.call_args[0][0]
     )
 
     # Case 2: Installed version is equal to required, should not warn.
     mock_log_warning.reset_mock()
+    mock_get_packages.reset_mock()
     mock_get_version.return_value = parse_version("2.0.0")
-    warn_deprecation_for_versions_less_than("my-package", "dep-package", "2.0.0")
+    warn_deprecation_for_versions_less_than("my.package", "dep.package", "2.0.0")
     mock_log_warning.assert_not_called()
 
     # Case 3: Installed version is greater than required, should not warn.
     mock_log_warning.reset_mock()
+    mock_get_packages.reset_mock()
     mock_get_version.return_value = parse_version("3.0.0")
-    warn_deprecation_for_versions_less_than("my-package", "dep-package", "2.0.0")
+    warn_deprecation_for_versions_less_than("my.package", "dep.package", "2.0.0")
     mock_log_warning.assert_not_called()
 
     # Case 4: Dependency not found, should not warn.
     mock_log_warning.reset_mock()
+    mock_get_packages.reset_mock()
     mock_get_version.return_value = None
-    warn_deprecation_for_versions_less_than("my-package", "dep-package", "2.0.0")
+    warn_deprecation_for_versions_less_than("my.package", "dep.package", "2.0.0")
     mock_log_warning.assert_not_called()
 
     # Case 5: Custom message template.
     mock_log_warning.reset_mock()
+    mock_get_packages.reset_mock()
+    mock_get_packages.side_effect = [
+        ("dep-package (dep.package)", "dep-package"),
+        ("my-package (my.package)", "my-package"),
+    ]
     mock_get_version.return_value = parse_version("1.0.0")
-    template = "Custom warning for {dependency_name} used by {dependent_package}."
+    template = "Custom warning for {dependency_packages} used by {dependent_packages}."
     warn_deprecation_for_versions_less_than(
-        "my-package", "dep-package", "2.0.0", message_template=template
+        "my.package", "dep.package", "2.0.0", message_template=template
     )
     mock_log_warning.assert_called_once()
     assert (
-        "Custom warning for dep-package used by my-package."
+        "Custom warning for dep-package (dep.package) used by my-package (my.package)."
         in mock_log_warning.call_args[0][0]
     )

--- a/tests/unit/test_python_package_support.py
+++ b/tests/unit/test_python_package_support.py
@@ -22,6 +22,8 @@ from packaging.version import parse as parse_version
 from google.api_core._python_package_support import (
     get_dependency_version,
     warn_deprecation_for_versions_less_than,
+    check_dependency_versions,
+    DependencyConstraint,
     DependencyVersion,
 )
 
@@ -124,12 +126,6 @@ def test_warn_deprecation_for_versions_less_than(mock_get_version, mock_get_pack
         "Custom warning for dep-package (dep.package) used by my-package (my.package)."
         in str(record[0].message)
     )
-
-
-from google.api_core._python_package_support import (
-    check_dependency_versions,
-    DependencyConstraint,
-)
 
 
 @patch(

--- a/tests/unit/test_python_package_support.py
+++ b/tests/unit/test_python_package_support.py
@@ -48,7 +48,9 @@ def test_get_dependency_version_py37(mock_get_distribution):
     mock_get_distribution.assert_called_once_with("another-package")
 
     # Test package not found
-    mock_get_distribution.side_effect = Exception  # pkg_resources has its own exception types
+    mock_get_distribution.side_effect = (
+        Exception  # pkg_resources has its own exception types
+    )
     assert get_dependency_version("not-a-package") is None
 
 
@@ -58,34 +60,29 @@ def test_warn_deprecation_for_versions_less_than(mock_log_warning, mock_get_vers
     """Test the deprecation warning logic."""
     # Case 1: Installed version is less than required, should warn.
     mock_get_version.return_value = parse_version("1.0.0")
-    warn_deprecation_for_versions_less_than(
-        "my-package", "dep-package", "2.0.0"
-    )
+    warn_deprecation_for_versions_less_than("my-package", "dep-package", "2.0.0")
     mock_log_warning.assert_called_once()
-    assert "DEPRECATION: Package my-package depends on dep-package" in mock_log_warning.call_args[0][0]
+    assert (
+        "DEPRECATION: Package my-package depends on dep-package"
+        in mock_log_warning.call_args[0][0]
+    )
 
     # Case 2: Installed version is equal to required, should not warn.
     mock_log_warning.reset_mock()
     mock_get_version.return_value = parse_version("2.0.0")
-    warn_deprecation_for_versions_less_than(
-        "my-package", "dep-package", "2.0.0"
-    )
+    warn_deprecation_for_versions_less_than("my-package", "dep-package", "2.0.0")
     mock_log_warning.assert_not_called()
 
     # Case 3: Installed version is greater than required, should not warn.
     mock_log_warning.reset_mock()
     mock_get_version.return_value = parse_version("3.0.0")
-    warn_deprecation_for_versions_less_than(
-        "my-package", "dep-package", "2.0.0"
-    )
+    warn_deprecation_for_versions_less_than("my-package", "dep-package", "2.0.0")
     mock_log_warning.assert_not_called()
 
     # Case 4: Dependency not found, should not warn.
     mock_log_warning.reset_mock()
     mock_get_version.return_value = None
-    warn_deprecation_for_versions_less_than(
-        "my-package", "dep-package", "2.0.0"
-    )
+    warn_deprecation_for_versions_less_than("my-package", "dep-package", "2.0.0")
     mock_log_warning.assert_not_called()
 
     # Case 5: Custom message template.
@@ -96,4 +93,7 @@ def test_warn_deprecation_for_versions_less_than(mock_log_warning, mock_get_vers
         "my-package", "dep-package", "2.0.0", message_template=template
     )
     mock_log_warning.assert_called_once()
-    assert "Custom warning for dep-package used by my-package." in mock_log_warning.call_args[0][0]
+    assert (
+        "Custom warning for dep-package used by my-package."
+        in mock_log_warning.call_args[0][0]
+    )

--- a/tests/unit/test_python_package_support.py
+++ b/tests/unit/test_python_package_support.py
@@ -49,7 +49,10 @@ def test_get_dependency_version_py37(mock_get_distribution):
     mock_dist = MagicMock()
     mock_dist.version = "4.5.6"
     mock_get_distribution.return_value = mock_dist
-    assert get_dependency_version("another-package") == (parse_version("4.5.6"), "4.5.6")
+    assert get_dependency_version("another-package") == (
+        parse_version("4.5.6"),
+        "4.5.6",
+    )
     mock_get_distribution.assert_called_once_with("another-package")
 
     # Test package not found
@@ -61,9 +64,7 @@ def test_get_dependency_version_py37(mock_get_distribution):
 
 @patch("google.api_core._python_package_support._get_distribution_and_import_packages")
 @patch("google.api_core._python_package_support.get_dependency_version")
-def test_warn_deprecation_for_versions_less_than(
-    mock_get_version, mock_get_packages
-):
+def test_warn_deprecation_for_versions_less_than(mock_get_version, mock_get_packages):
     """Test the deprecation warning logic."""
     # Mock the helper function to return predictable package strings
     mock_get_packages.side_effect = [

--- a/tests/unit/test_python_package_support.py
+++ b/tests/unit/test_python_package_support.py
@@ -114,7 +114,7 @@ def test_warn_deprecation_for_versions_less_than(mock_get_version, mock_get_pack
         ("my-package (my.package)", "my-package"),
     ]
     mock_get_version.return_value = DependencyVersion(parse_version("1.0.0"), "1.0.0")
-    template = "Custom warning for {dependency_package} used by {dependent_package}."
+    template = "Custom warning for {dependency_package} used by {consumer_package}."
     with pytest.warns(FutureWarning) as record:
         warn_deprecation_for_versions_less_than(
             "my.package", "dep.package", "2.0.0", message_template=template

--- a/tests/unit/test_python_package_support.py
+++ b/tests/unit/test_python_package_support.py
@@ -124,3 +124,22 @@ def test_warn_deprecation_for_versions_less_than(mock_get_version, mock_get_pack
         "Custom warning for dep-package (dep.package) used by my-package (my.package)."
         in str(record[0].message)
     )
+
+
+from google.api_core._python_package_support import (
+    check_dependency_versions,
+    DependencyConstraint,
+)
+
+
+@patch("google.api_core._python_package_support.warn_deprecation_for_versions_less_than")
+def test_check_dependency_versions_with_custom_warnings(mock_warn):
+    """Test check_dependency_versions with custom warning parameters."""
+    custom_warning1 = DependencyConstraint("pkg1", "1.0.0", "2.0.0")
+    custom_warning2 = DependencyConstraint("pkg2", "2.0.0", "3.0.0")
+
+    check_dependency_versions("my-consumer", custom_warning1, custom_warning2)
+
+    assert mock_warn.call_count == 2
+    mock_warn.assert_any_call("my-consumer", "pkg1", "1.0.0", recommended_version="2.0.0")
+    mock_warn.assert_any_call("my-consumer", "pkg2", "2.0.0", recommended_version="3.0.0")

--- a/tests/unit/test_python_package_support.py
+++ b/tests/unit/test_python_package_support.py
@@ -24,6 +24,8 @@ from google.api_core._python_package_support import (
 )
 
 
+# TODO(https://github.com/googleapis/python-api-core/issues/835): Remove
+# this mark once we drop support for Python 3.7
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
 @patch("importlib.metadata.version")
 def test_get_dependency_version_py38_plus(mock_version):
@@ -37,6 +39,8 @@ def test_get_dependency_version_py38_plus(mock_version):
     assert get_dependency_version("not-a-package") is None
 
 
+# TODO(https://github.com/googleapis/python-api-core/issues/835): Remove
+# this test function once we drop support for Python 3.7
 @pytest.mark.skipif(sys.version_info >= (3, 8), reason="requires python3.7")
 @patch("pkg_resources.get_distribution")
 def test_get_dependency_version_py37(mock_get_distribution):

--- a/tests/unit/test_python_package_support.py
+++ b/tests/unit/test_python_package_support.py
@@ -132,7 +132,9 @@ from google.api_core._python_package_support import (
 )
 
 
-@patch("google.api_core._python_package_support.warn_deprecation_for_versions_less_than")
+@patch(
+    "google.api_core._python_package_support.warn_deprecation_for_versions_less_than"
+)
 def test_check_dependency_versions_with_custom_warnings(mock_warn):
     """Test check_dependency_versions with custom warning parameters."""
     custom_warning1 = DependencyConstraint("pkg1", "1.0.0", "2.0.0")
@@ -141,5 +143,9 @@ def test_check_dependency_versions_with_custom_warnings(mock_warn):
     check_dependency_versions("my-consumer", custom_warning1, custom_warning2)
 
     assert mock_warn.call_count == 2
-    mock_warn.assert_any_call("my-consumer", "pkg1", "1.0.0", recommended_version="2.0.0")
-    mock_warn.assert_any_call("my-consumer", "pkg2", "2.0.0", recommended_version="3.0.0")
+    mock_warn.assert_any_call(
+        "my-consumer", "pkg1", "1.0.0", recommended_version="2.0.0"
+    )
+    mock_warn.assert_any_call(
+        "my-consumer", "pkg2", "2.0.0", recommended_version="3.0.0"
+    )

--- a/tests/unit/test_python_version_support.py
+++ b/tests/unit/test_python_version_support.py
@@ -166,7 +166,7 @@ def test_override_gapic_end_only():
                 today=custom_gapic_end + datetime.timedelta(days=-1)
             )
             assert (
-                result_before_boundary == PythonVersionStatus.PYTHON_VERSION_DEPRECATED
+                result_before_boundary == PythonVersionStatus.PYTHON_VERSION_EOL
             )
 
             result_at_boundary = check_python_version(today=custom_gapic_end)

--- a/tests/unit/test_python_version_support.py
+++ b/tests/unit/test_python_version_support.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 
 # Code to be tested
 from google.api_core._python_version_support import (
+    _flatten_message,
     check_python_version,
     PythonVersionStatus,
     PYTHON_VERSION_INFO,
@@ -29,6 +30,17 @@ from google.api_core._python_version_support import (
 
 # Helper object for mocking sys.version_info
 VersionInfoMock = namedtuple("VersionInfoMock", ["major", "minor"])
+
+
+def test_flatten_message():
+    """Test that _flatten_message correctly dedents and flattens a string."""
+    input_text = """
+        This is a multi-line
+        string with some
+            indentation.
+    """
+    expected_output = "This is a multi-line string with some indentation."
+    assert _flatten_message(input_text) == expected_output
 
 
 def _create_failure_message(

--- a/tests/unit/test_python_version_support.py
+++ b/tests/unit/test_python_version_support.py
@@ -34,7 +34,7 @@ def _create_failure_message(
     expected, result, py_version, date, gapic_dep, py_eol, eol_warn, gapic_end
 ):
     """Create a detailed failure message for a test."""
-    return textwrap.dedent(
+    return textwrap.dedent(  # pragma: NO COVER
         f"""
         --- Test Failed ---
         Expected status: {expected.name}
@@ -129,7 +129,7 @@ def test_all_tracked_versions_and_date_scenarios(
                 (result != expected_status)
                 or (result != PythonVersionStatus.PYTHON_VERSION_SUPPORTED)
                 and mock_log.call_count != 1
-            ):
+            ):  # pragma: NO COVER
                 py_version_str = f"{version_tuple[0]}.{version_tuple[1]}"
                 version_info = PYTHON_VERSION_INFO[version_tuple]
 

--- a/tests/unit/test_python_version_support.py
+++ b/tests/unit/test_python_version_support.py
@@ -163,8 +163,11 @@ def test_override_gapic_end_only():
             {version_tuple: overridden_info},
         ):
             result_before_boundary = check_python_version(
-                today=custom_gapic_end + datetime.timedelta(days=-1))
-            assert result_before_boundary == PythonVersionStatus.PYTHON_VERSION_DEPRECATED
+                today=custom_gapic_end + datetime.timedelta(days=-1)
+            )
+            assert (
+                result_before_boundary == PythonVersionStatus.PYTHON_VERSION_DEPRECATED
+            )
 
             result_at_boundary = check_python_version(today=custom_gapic_end)
             assert result_at_boundary == PythonVersionStatus.PYTHON_VERSION_EOL

--- a/tests/unit/test_python_version_support.py
+++ b/tests/unit/test_python_version_support.py
@@ -129,7 +129,7 @@ def test_all_tracked_versions_and_date_scenarios(
                 assert len(w) == 0
         # All other statuses should issue a warning
         else:
-            with pytest.warns(UserWarning) as record:
+            with pytest.warns(FutureWarning) as record:
                 result = check_python_version(today=mock_date)
             assert len(record) == 1
 
@@ -216,7 +216,7 @@ def test_untracked_older_version_is_unsupported():
     with patch(
         "google.api_core._python_version_support.sys.version_info", mock_py_version
     ):
-        with pytest.warns(UserWarning) as record:
+        with pytest.warns(FutureWarning) as record:
             mock_date = datetime.date(2025, 1, 15)
             result = check_python_version(today=mock_date)
 

--- a/tests/unit/test_python_version_support.py
+++ b/tests/unit/test_python_version_support.py
@@ -1,0 +1,206 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import datetime
+import textwrap
+from collections import namedtuple
+
+from unittest.mock import patch
+
+# Code to be tested
+from google.api_core._python_version_support import (
+    check_python_version,
+    PythonVersionStatus,
+    PYTHON_VERSION_INFO,
+)
+
+# Helper object for mocking sys.version_info
+VersionInfoMock = namedtuple("VersionInfoMock", ["major", "minor"])
+
+
+def _create_failure_message(expected, result, py_version, date,
+                            gapic_dep, py_eol, eol_warn, gapic_end):
+    """Create a detailed failure message for a test."""
+    return textwrap.dedent(
+        f"""
+        --- Test Failed ---
+        Expected status: {expected.name}
+        Received status: {result.name}
+        ---------------------
+        Context:
+          - Mocked Python Version: {py_version}
+          - Mocked Today's Date:   {date}
+        Calculated Dates:
+          - gapic_deprecation:     {gapic_dep}
+          - python_eol:            {py_eol}
+          - eol_warning_starts:    {eol_warn}
+          - gapic_end:             {gapic_end}
+        """
+    )
+
+
+def generate_tracked_version_test_cases():
+    """
+    Yields test parameters for all tracked versions and boundary conditions.
+    """
+    for version_tuple, version_info in PYTHON_VERSION_INFO.items():
+        py_version_str = f"{version_tuple[0]}.{version_tuple[1]}"
+        gapic_dep = version_info.gapic_deprecation or (
+            version_info.python_eol - datetime.timedelta(days=365)
+        )
+        gapic_end = version_info.gapic_end or (
+            version_info.python_eol + datetime.timedelta(weeks=1)
+        )
+        eol_warning_starts = version_info.python_eol + datetime.timedelta(weeks=1)
+
+        test_cases = {
+            "supported_before_deprecation_date": {
+                "date": gapic_dep - datetime.timedelta(days=1),
+                "expected": PythonVersionStatus.PYTHON_VERSION_SUPPORTED,
+            },
+            "deprecated_on_deprecation_date": {
+                "date": gapic_dep,
+                "expected": PythonVersionStatus.PYTHON_VERSION_DEPRECATED,
+            },
+            "deprecated_on_eol_date": {
+                "date": version_info.python_eol,
+                "expected": PythonVersionStatus.PYTHON_VERSION_DEPRECATED,
+            },
+            "deprecated_before_eol_warning_starts": {
+                "date": eol_warning_starts - datetime.timedelta(days=1),
+                "expected": PythonVersionStatus.PYTHON_VERSION_DEPRECATED,
+            },
+            "eol_on_eol_warning_date": {
+                "date": eol_warning_starts,
+                "expected": PythonVersionStatus.PYTHON_VERSION_EOL,
+            },
+            "eol_on_gapic_end_date": {
+                "date": gapic_end,
+                "expected": PythonVersionStatus.PYTHON_VERSION_EOL,
+            },
+            "unsupported_after_gapic_end_date": {
+                "date": gapic_end + datetime.timedelta(days=1),
+                "expected": PythonVersionStatus.PYTHON_VERSION_UNSUPPORTED,
+            },
+        }
+
+        for name, params in test_cases.items():
+            yield pytest.param(
+                version_tuple, params["date"], params["expected"],
+                gapic_dep, gapic_end, eol_warning_starts,
+                id=f"{py_version_str}-{name}"
+            )
+
+
+@pytest.mark.parametrize(
+    "version_tuple, mock_date, expected_status, gapic_dep, gapic_end, eol_warning_starts",
+    generate_tracked_version_test_cases()
+)
+def test_all_tracked_versions_and_date_scenarios(
+    version_tuple, mock_date, expected_status, gapic_dep, gapic_end,
+    eol_warning_starts
+):
+    """Test all outcomes for each tracked version using parametrization."""
+    mock_py_v = VersionInfoMock(
+        major=version_tuple[0], minor=version_tuple[1]
+    )
+
+    with patch("google.api_core._python_version_support.sys.version_info", mock_py_v):
+        with patch("google.api_core._python_version_support.logging.warning") as mock_log:
+            result = check_python_version(today=mock_date)
+
+            if ((result != expected_status) or
+                (result != PythonVersionStatus.PYTHON_VERSION_SUPPORTED) and mock_log.call_count != 1):
+                py_version_str = f"{version_tuple[0]}.{version_tuple[1]}"
+                version_info = PYTHON_VERSION_INFO[version_tuple]
+
+                fail_msg = _create_failure_message(
+                    expected_status, result, py_version_str,
+                    mock_date, gapic_dep, version_info.python_eol,
+                    eol_warning_starts, gapic_end
+                )
+                pytest.fail(fail_msg, pytrace=False)
+
+
+def test_override_gapic_end_only():
+    """Test behavior when only gapic_end is manually overridden."""
+    version_tuple = (3, 9)
+    original_info = PYTHON_VERSION_INFO[version_tuple]
+    mock_py_version = VersionInfoMock(
+        major=version_tuple[0], minor=version_tuple[1]
+    )
+
+    custom_gapic_end = original_info.python_eol + datetime.timedelta(days=212)
+    overridden_info = original_info._replace(gapic_end=custom_gapic_end)
+
+    with patch("google.api_core._python_version_support.sys.version_info", mock_py_version):
+        with patch.dict('google.api_core._python_version_support.PYTHON_VERSION_INFO', {version_tuple: overridden_info}):
+            result_at_boundary = check_python_version(today=custom_gapic_end)
+            assert result_at_boundary == PythonVersionStatus.PYTHON_VERSION_EOL
+
+            result_after_boundary = check_python_version(
+                today=custom_gapic_end + datetime.timedelta(days=1)
+            )
+            assert result_after_boundary == PythonVersionStatus.PYTHON_VERSION_UNSUPPORTED
+
+
+def test_override_gapic_deprecation_only():
+    """Test behavior when only gapic_deprecation is manually overridden."""
+    version_tuple = (3, 9)
+    original_info = PYTHON_VERSION_INFO[version_tuple]
+    mock_py_version = VersionInfoMock(
+        major=version_tuple[0], minor=version_tuple[1]
+    )
+
+    custom_gapic_dep = original_info.python_eol - datetime.timedelta(days=120)
+    overridden_info = original_info._replace(gapic_deprecation=custom_gapic_dep)
+
+    with patch("google.api_core._python_version_support.sys.version_info", mock_py_version):
+        with patch.dict('google.api_core._python_version_support.PYTHON_VERSION_INFO', {version_tuple: overridden_info}):
+            result_before_boundary = check_python_version(
+                today=custom_gapic_dep - datetime.timedelta(days=1)
+            )
+            assert result_before_boundary == PythonVersionStatus.PYTHON_VERSION_SUPPORTED
+
+            result_at_boundary = check_python_version(today=custom_gapic_dep)
+            assert result_at_boundary == PythonVersionStatus.PYTHON_VERSION_DEPRECATED
+
+
+def test_untracked_older_version_is_unsupported():
+    """Test that an old, untracked version is unsupported and logs."""
+    mock_py_version = VersionInfoMock(major=3, minor=6)
+
+    with patch("google.api_core._python_version_support.sys.version_info", mock_py_version):
+        with patch("google.api_core._python_version_support.logging.warning") as mock_log:
+            mock_date = datetime.date(2025, 1, 15)
+            result = check_python_version(today=mock_date)
+
+            assert result == PythonVersionStatus.PYTHON_VERSION_UNSUPPORTED
+            mock_log.assert_called_once()
+            call_args = mock_log.call_args[0][0]
+            assert "non-supported" in call_args
+
+
+def test_untracked_newer_version_is_supported():
+    """Test that a new, untracked version is supported and does not log."""
+    mock_py_version = VersionInfoMock(major=4, minor=0)
+
+    with patch("google.api_core._python_version_support.sys.version_info", mock_py_version):
+        with patch("google.api_core._python_version_support.logging.warning") as mock_log:
+            mock_date = datetime.date(2025, 1, 15)
+            result = check_python_version(today=mock_date)
+
+            assert result == PythonVersionStatus.PYTHON_VERSION_SUPPORTED
+            mock_log.assert_not_called()

--- a/tests/unit/test_python_version_support.py
+++ b/tests/unit/test_python_version_support.py
@@ -165,9 +165,7 @@ def test_override_gapic_end_only():
             result_before_boundary = check_python_version(
                 today=custom_gapic_end + datetime.timedelta(days=-1)
             )
-            assert (
-                result_before_boundary == PythonVersionStatus.PYTHON_VERSION_EOL
-            )
+            assert result_before_boundary == PythonVersionStatus.PYTHON_VERSION_EOL
 
             result_at_boundary = check_python_version(today=custom_gapic_end)
             assert result_at_boundary == PythonVersionStatus.PYTHON_VERSION_EOL

--- a/tests/unit/test_python_version_support.py
+++ b/tests/unit/test_python_version_support.py
@@ -162,6 +162,10 @@ def test_override_gapic_end_only():
             "google.api_core._python_version_support.PYTHON_VERSION_INFO",
             {version_tuple: overridden_info},
         ):
+            result_before_boundary = check_python_version(
+                today=custom_gapic_end + datetime.timedelta(days=-1))
+            assert result_before_boundary == PythonVersionStatus.PYTHON_VERSION_DEPRECATED
+
             result_at_boundary = check_python_version(today=custom_gapic_end)
             assert result_at_boundary == PythonVersionStatus.PYTHON_VERSION_EOL
 
@@ -221,7 +225,7 @@ def test_untracked_older_version_is_unsupported():
 
 def test_untracked_newer_version_is_supported():
     """Test that a new, untracked version is supported and does not log."""
-    mock_py_version = VersionInfoMock(major=4, minor=0)
+    mock_py_version = VersionInfoMock(major=40, minor=0)
 
     with patch(
         "google.api_core._python_version_support.sys.version_info", mock_py_version

--- a/tests/unit/test_timeout.py
+++ b/tests/unit/test_timeout.py
@@ -14,6 +14,7 @@
 
 import datetime
 import itertools
+import pytest
 from unittest import mock
 
 from google.api_core import timeout as timeouts
@@ -121,7 +122,15 @@ class TestTimeToDeadlineTimeout(object):
 
         wrapped(1, 2, meep="moop")
 
-        target.assert_called_once_with(1, 2, meep="moop", timeout=42.0)
+        actual_arg_0 = target.call_args[0][0]
+        actual_arg_1 = target.call_args[0][1]
+        actual_arg_meep = target.call_args[1]["meep"]
+        actual_arg_timeuut = target.call_args[1]["timeout"]
+
+        assert actual_arg_0 == 1
+        assert actual_arg_1 == 2
+        assert actual_arg_meep == "moop"
+        assert actual_arg_timeuut == pytest.approx(42.0, abs=0.01)
 
 
 class TestConstantTimeout(object):


### PR DESCRIPTION
This exports a function `check_python_version` that dependent packages can use to verify the run-time version on which they are running and warn users when they need to upgrade their Python version. `google.api_core` also applies this function to itself.