### PR TITLE
fix: fix async tests and round-off error in test expectations

### DIFF
--- a/tests/asyncio/gapic/test_method_async.py
+++ b/tests/asyncio/gapic/test_method_async.py
@@ -256,7 +256,11 @@ async def test_wrap_method_with_overriding_timeout_as_a_number():
     result = await wrapped_method(timeout=22)
 
     assert result == 42
-    method.assert_called_once_with(timeout=22, metadata=mock.ANY)
+
+    actual_timeout = method.call_args[1]["timeout"]
+    metadata = method.call_args[1]["metadata"]
+    assert metadata == mock.ANY
+    assert actual_timeout == pytest.approx(22, abs=0.01)
 
 
 @pytest.mark.asyncio

--- a/tests/asyncio/test_operation_async.py
+++ b/tests/asyncio/test_operation_async.py
@@ -178,7 +178,7 @@ async def test_unexpected_result(unused_sleep):
 
 
 @pytest.mark.asyncio
-def test_from_gapic():
+async def test_from_gapic():
     operation_proto = make_operation_proto(done=True)
     operations_client = mock.create_autospec(
         operations_v1.OperationsClient, instance=True

--- a/tests/asyncio/test_operation_async.py
+++ b/tests/asyncio/test_operation_async.py
@@ -85,7 +85,7 @@ async def test_constructor():
 
 
 @pytest.mark.asyncio
-def test_metadata():
+async def test_metadata():
     expected_metadata = struct_pb2.Struct()
     future, _, _ = make_operation_future(
         [make_operation_proto(metadata=expected_metadata)]

--- a/tests/unit/gapic/test_method.py
+++ b/tests/unit/gapic/test_method.py
@@ -201,7 +201,11 @@ def test_wrap_method_with_overriding_timeout_as_a_number():
     result = wrapped_method(timeout=22)
 
     assert result == 42
-    method.assert_called_once_with(timeout=22, metadata=mock.ANY)
+
+    actual_timeout = method.call_args[1]["timeout"]
+    metadata = method.call_args[1]["metadata"]
+    assert metadata == mock.ANY
+    assert actual_timeout == pytest.approx(22, abs=0.01)
 
 
 def test_wrap_method_with_call():


### PR DESCRIPTION
Some test methods to test async functionality had `@pytest.mark.asyncio` but were not themselves designated as `async` methods. This led to warnings.

Some of the tests also started failing under Python 3.14 because the numeric comparisons were not exact. These changes makes those expectations be somewhat approximate.