### PR TITLE
fix: closes tailing streams in bidi classes.

### DIFF
--- a/google/api_core/bidi.py
+++ b/google/api_core/bidi.py
@@ -281,11 +281,11 @@ class BidiRpc(BidiRpcBase):
 
     def close(self):
         """Closes the stream."""
-        if self.call is None:
-            return
+        if self.call is not None:
+            self.call.cancel()
 
+        # Put None in request queue to signal termination.
         self._request_queue.put(None)
-        self.call.cancel()
         self._request_generator = None
         self._initial_request = None
         self._callbacks = []

--- a/google/api_core/bidi_async.py
+++ b/google/api_core/bidi_async.py
@@ -197,11 +197,11 @@ class AsyncBidiRpc(BidiRpcBase):
 
     async def close(self) -> None:
         """Closes the stream."""
-        if self.call is None:
-            return
+        if self.call is not None:
+            self.call.cancel()
 
+        # Put None in request queue to signal termination.
         await self._request_queue.put(None)
-        self.call.cancel()
         self._request_generator = None
         self._initial_request = None
         self._callbacks = []

--- a/tests/asyncio/test_bidi_async.py
+++ b/tests/asyncio/test_bidi_async.py
@@ -256,6 +256,21 @@ class TestAsyncBidiRpc:
         assert not bidi_rpc._callbacks
 
     @pytest.mark.asyncio
+    async def test_close_with_no_rpc(self):
+        bidi_rpc = bidi_async.AsyncBidiRpc(None)
+
+        await bidi_rpc.close()
+
+        assert bidi_rpc.call is None
+        assert bidi_rpc.is_active is False
+        # ensure the request queue was signaled to stop.
+        assert bidi_rpc.pending_requests == 1
+        assert await bidi_rpc._request_queue.get() is None
+        # ensure request and callbacks are cleaned up
+        assert bidi_rpc._initial_request is None
+        assert not bidi_rpc._callbacks
+
+    @pytest.mark.asyncio
     async def test_close_no_rpc(self):
         bidi_rpc = bidi_async.AsyncBidiRpc(None)
         await bidi_rpc.close()

--- a/tests/unit/test_bidi.py
+++ b/tests/unit/test_bidi.py
@@ -301,9 +301,18 @@ class TestBidiRpc(object):
         assert bidi_rpc._initial_request is None
         assert not bidi_rpc._callbacks
 
-    def test_close_no_rpc(self):
+    def test_close_with_no_rpc(self):
         bidi_rpc = bidi.BidiRpc(None)
         bidi_rpc.close()
+
+        assert bidi_rpc.call is None
+        assert bidi_rpc.is_active is False
+        # ensure the request queue was signaled to stop.
+        assert bidi_rpc.pending_requests == 1
+        assert bidi_rpc._request_queue.get() is None
+        # ensure request and callbacks are cleaned up
+        assert bidi_rpc._initial_request is None
+        assert not bidi_rpc._callbacks
 
     def test_send(self):
         rpc, call = make_rpc()


### PR DESCRIPTION
Always put `None` into the request queue when closing a bidi stream. This ensures that the request queue is always signaled as closed, even if the underlying gRPC call object is not yet available.

Fixes #850  🦕
