### PR TITLE
feat: Auto enable mTLS when supported certificates are detected

### DIFF
--- a/google/api_core/operations_v1/abstract_operations_base_client.py
+++ b/google/api_core/operations_v1/abstract_operations_base_client.py
@@ -304,7 +304,9 @@ class AbstractOperationsBaseClient(metaclass=AbstractOperationsBaseClientMeta):
             use_client_cert = mtls.should_use_client_cert()
         else:
             # if unsupported, fallback to reading from env var
-            use_client_cert_str = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false").lower()
+            use_client_cert_str = os.getenv(
+                "GOOGLE_API_USE_CLIENT_CERTIFICATE", "false"
+            ).lower()
             if use_client_cert_str not in ("true", "false"):
                 raise ValueError(
                     "Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be"

--- a/tests/unit/operations_v1/test_operations_rest_client.py
+++ b/tests/unit/operations_v1/test_operations_rest_client.py
@@ -351,11 +351,16 @@ def test_operations_client_client_options(
     with mock.patch.dict(
         os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "Unsupported"}
     ):
-        if hasattr(google.auth.transport.mtls, "should_use_client_cert"):
-            pytest.skip(
-                "The should_use_client_cert function is available in this "
-                "version of google-auth. Skipping this test."
-            )
+        if not hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+            with pytest.raises(ValueError):
+                client = client_class()
+        else:
+             with mock.patch.object(transport_class, "__init__") as patched:
+                patched.return_value = None
+                client = client_class(
+                    credentials=ga_credentials.AnonymousCredentials(),
+                    transport=transport_name
+                )
 
     # Check the case quota_project_id is provided
     options = client_options.ClientOptions(quota_project_id="octopus")

--- a/tests/unit/operations_v1/test_operations_rest_client.py
+++ b/tests/unit/operations_v1/test_operations_rest_client.py
@@ -35,6 +35,7 @@ from google.auth.transport.requests import AuthorizedSession
 from google.api_core import client_options
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
+from google.api_core import parse_version_to_tuple
 from google.api_core.operations_v1 import AbstractOperationsClient
 
 import google.auth
@@ -42,6 +43,7 @@ from google.api_core.operations_v1 import pagers
 from google.api_core.operations_v1 import pagers_async
 from google.api_core.operations_v1 import transports
 from google.auth import credentials as ga_credentials
+from google.auth import __version__ as auth_version
 from google.auth.exceptions import MutualTLSChannelError
 from google.longrunning import operations_pb2
 from google.oauth2 import service_account
@@ -346,14 +348,23 @@ def test_operations_client_client_options(
         with pytest.raises(MutualTLSChannelError):
             client = client_class()
 
-    # Check the case GOOGLE_API_USE_CLIENT_CERTIFICATE has unsupported value and
-    # should_use_client_cert is unavailable.
+    # Check the case GOOGLE_API_USE_CLIENT_CERTIFICATE has unsupported value
     with mock.patch.dict(
         os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "Unsupported"}
     ):
-        if not hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+        # Test behavior for google.auth versions < 2.43.0.
+        # These versions do not have the updated mtls.should_use_client_cert logic.
+        # Verify that a ValueError is raised when GOOGLE_API_USE_CLIENT_CERTIFICATE
+        # is set to an unsupported value, as expected in these older versions.
+        if parse_version_to_tuple(auth_version) < (2, 43, 0):
             with pytest.raises(ValueError):
                 client = client_class()
+        # Test behavior for google.auth versions >= 2.43.0.
+        # In these versions, if GOOGLE_API_USE_CLIENT_CERTIFICATE is set to an
+        # unsupported value (e.g., not 'true' or 'false'), the expected behavior
+        # of the internal google.auth.mtls.should_use_client_cert() function
+        # is to return False. Expect should_use_client_cert to return False, so
+        # client creation should proceed without requiring a client certificate.
         else:
             with mock.patch.object(transport_class, "__init__") as patched:
                 patched.return_value = None

--- a/tests/unit/operations_v1/test_operations_rest_client.py
+++ b/tests/unit/operations_v1/test_operations_rest_client.py
@@ -355,11 +355,11 @@ def test_operations_client_client_options(
             with pytest.raises(ValueError):
                 client = client_class()
         else:
-             with mock.patch.object(transport_class, "__init__") as patched:
+            with mock.patch.object(transport_class, "__init__") as patched:
                 patched.return_value = None
                 client = client_class(
                     credentials=ga_credentials.AnonymousCredentials(),
-                    transport=transport_name
+                    transport=transport_name,
                 )
 
     # Check the case quota_project_id is provided

--- a/tests/unit/operations_v1/test_operations_rest_client.py
+++ b/tests/unit/operations_v1/test_operations_rest_client.py
@@ -346,12 +346,16 @@ def test_operations_client_client_options(
         with pytest.raises(MutualTLSChannelError):
             client = client_class()
 
-    # Check the case GOOGLE_API_USE_CLIENT_CERTIFICATE has unsupported value.
+    # Check the case GOOGLE_API_USE_CLIENT_CERTIFICATE has unsupported value and
+    # should_use_client_cert is unavailable.
     with mock.patch.dict(
         os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "Unsupported"}
     ):
-        with pytest.raises(ValueError):
-            client = client_class()
+        if hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+            pytest.skip(
+                "The should_use_client_cert function is available in this "
+                "version of google-auth. Skipping this test."
+            )
 
     # Check the case quota_project_id is provided
     options = client_options.ClientOptions(quota_project_id="octopus")


### PR DESCRIPTION
The Python SDK will use a hybrid approach for mTLS enablement:

If the GOOGLE_API_USE_CLIENT_CERTIFICATE environment variable is set (either true or false or any value), the SDK will respect that setting. This is necessary for test scenarios and users who need to explicitly control mTLS behavior.
If the GOOGLE_API_USE_CLIENT_CERTIFICATE environment variable is not set, the SDK will automatically enable mTLS only if it detects Managed Workload Identity (MWID) or X.509 Workforce Identity Federation (WIF) certificate sources. In other cases where the variable is not set, mTLS will remain disabled.