### PR TITLE
tests: refactor unit test nox sessions

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -6,7 +6,31 @@ on:
       - main
 
 jobs:
-  run-unittests:
+  unit-prerelease:
+    name: prerelease_deps
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.14"]
+        option: ["prerelease"]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python }}
+        allow-prereleases: true
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install nox
+    - name: Run ${{ matrix.option }} tests
+      env:
+        COVERAGE_FILE: .coverage${{ matrix.option }}-${{matrix.python }}
+      run: |
+        nox -s prerelease_deps
+  unit:
     name: unit${{ matrix.option }}-${{ matrix.python }}
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2303): use `ubuntu-latest` once this bug is fixed.
     # Use ubuntu-22.04 until Python 3.7 is removed from the test matrix
@@ -14,7 +38,6 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        option: ["", "_grpc_gcp", "_wo_grpc", "_w_prerelease_deps", "_w_async_rest_extra"]
         python:
           - "3.7"
           - "3.8"
@@ -24,13 +47,6 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
-        exclude:
-          - option: "_wo_grpc"
-            python: 3.7
-          - option: "_wo_grpc"
-            python: 3.8
-          - option: "_wo_grpc"
-            python: 3.9
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -45,21 +61,21 @@ jobs:
         python -m pip install nox
     - name: Run unit tests
       env:
-        COVERAGE_FILE: .coverage${{ matrix.option }}-${{matrix.python }}
+        COVERAGE_FILE: .coverage-${{matrix.python }}
       run: |
-        nox -s unit${{ matrix.option }}-${{ matrix.python }}
+        nox -s unit-${{ matrix.python }}
     - name: Upload coverage results
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-artifact-${{ matrix.option }}-${{ matrix.python }}
-        path: .coverage${{ matrix.option }}-${{ matrix.python }}
+        name: coverage-artifact-${{ matrix.python }}
+        path: .coverage-${{ matrix.python }}
         include-hidden-files: true
 
   report-coverage:
     name: cover
     runs-on: ubuntu-latest
     needs:
-        - run-unittests
+        - unit
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/noxfile.py
+++ b/noxfile.py
@@ -246,7 +246,7 @@ def unit(session, install_grpc_gcp, install_grpc, install_async_rest):
     )
 
 
-@nox.session(python=PYTHON_VERSIONS)
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def prerelease_deps(session):
     """Run the unit test suite."""
     default(session, prerelease=True)


### PR DESCRIPTION
This change is needed as part of b/463296248. Instead of having 4 different presubmits that run 4 different nox unit tests, we now have all 4 patterns tested under a single nox session. This follows the pattern that we have in google-cloud-python where there is a single unit test nox session.