### PR TITLE
tests: remove pytype nox session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -20,7 +20,7 @@ import shutil
 import unittest
 
 # https://github.com/google/importlab/issues/25
-import nox  # pytype: disable=import-error
+import nox
 
 
 BLACK_VERSION = "black==23.7.0"
@@ -41,7 +41,6 @@ nox.options.sessions = [
     "unit_w_prerelease_deps",
     "unit_w_async_rest_extra",
     "cover",
-    "pytype",
     "mypy",
     "lint",
     "lint_setup_py",
@@ -258,13 +257,6 @@ def lint_setup_py(session):
 
     session.install("docutils", "Pygments", "setuptools")
     session.run("python", "setup.py", "check", "--restructuredtext", "--strict")
-
-
-@nox.session(python=DEFAULT_PYTHON_VERSION)
-def pytype(session):
-    """Run type-checking."""
-    session.install(".[grpc]", "pytype")
-    session.run("pytype")
 
 
 @nox.session(python=DEFAULT_PYTHON_VERSION)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,0 @@
-[pytype]
-python_version = 3.7
-inputs =
-    google/
-exclude =
-    tests/
-output = .pytype/
-# Workaround for https://github.com/google/pytype/issues/150
-disable = pyi-error


### PR DESCRIPTION
The `pytype` nox session was not running as a presubmit so I've removed it. `pytype` is deprecated as per [this note](https://github.com/google/pytype?tab=readme-ov-file#an-update-on-pytype).