### PR TITLE
fix: preserve exception cause

### DIFF
--- a/google/api_core/retry/retry_base.py
+++ b/google/api_core/retry/retry_base.py
@@ -164,8 +164,10 @@ def build_retry_error(
             src_exc,
         )
     elif exc_list:
-        # return most recent exception encountered
-        return exc_list[-1], None
+        # return most recent exception encountered and its cause
+        final_exc = exc_list[-1]
+        cause = getattr(final_exc, '__cause__', None)
+        return final_exc, cause
     else:
         # no exceptions were given in exc_list. Raise generic RetryError
         return exceptions.RetryError("Unknown error", None), None

--- a/google/api_core/retry/retry_base.py
+++ b/google/api_core/retry/retry_base.py
@@ -166,7 +166,7 @@ def build_retry_error(
     elif exc_list:
         # return most recent exception encountered and its cause
         final_exc = exc_list[-1]
-        cause = getattr(final_exc, '__cause__', None)
+        cause = getattr(final_exc, "__cause__", None)
         return final_exc, cause
     else:
         # no exceptions were given in exc_list. Raise generic RetryError

--- a/tests/unit/retry/test_retry_base.py
+++ b/tests/unit/retry/test_retry_base.py
@@ -74,6 +74,26 @@ def test_build_retry_error_empty_list():
     assert src.message == "Unknown error"
 
 
+def test_build_retry_error_preserves_cause():
+    """
+    build_retry_error should preserve __cause__ from chained exceptions.
+    """
+    from google.api_core.retry import build_retry_error
+    from google.api_core.retry import RetryFailureReason
+
+    # Create an exception with explicit cause
+    cause = ValueError("root cause")
+    exc = RuntimeError("wrapper")
+    exc.__cause__ = cause
+
+    src, found_cause = build_retry_error(
+        [exc], RetryFailureReason.NON_RETRYABLE_ERROR, None
+    )
+
+    assert src is exc
+    assert found_cause is cause
+
+
 def test_build_retry_error_timeout_message():
     """
     should provide helpful error message when timeout is reached


### PR DESCRIPTION
Fixes https://github.com/googleapis/python-api-core/issues/880

## Problem:
When the retry mechanism re-raises non-retryable exceptions, it explicitly clears the exception chain by using raise final_exc from None. This breaks explicit exception chaining created with raise ... from ..., making the original cause (__cause__) inaccessible for debugging.

## Fix:
Modified `_default_exception_factory()` in `retry_base.py` to preserve the `__cause__` attribute when re-raising non-retryable exceptions. Instead of returning `(exc_list[-1], None)`, we now return `(exc_list[-1], getattr(exc_list[-1], '__cause__', None))`.

This ensures that exception chains are maintained through the retry mechanism, preserving debugging information and meeting developer expectations for exception handling.

## Testing:
Added a new test case in `tests/unit/retry/test_retry_base.py` that checks that the cause from the chained exception is preserved by `build_retry_error`.

---

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-api-core/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
