### PR TITLE
chore: librarian release pull request: 20260108T122817Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,8 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: google-api-core
-    version: 2.28.1
+    version: 2.29.0
+    last_generated_commit: ""
     apis: []
     source_roots:
       - .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 [1]: https://pypi.org/project/google-api-core/#history
 
+## [2.29.0](https://github.com/googleapis/google-cloud-python/compare/google-api-core-v2.28.1...google-api-core-v2.29.0) (2026-01-08)
+
+
+### Features
+
+* Auto enable mTLS when supported certificates are detected (#869) ([f8bf6f9610f3e0e7580f223794c3906513e1fa73](https://github.com/googleapis/google-cloud-python/commit/f8bf6f9610f3e0e7580f223794c3906513e1fa73))
+* make parse_version_to_tuple public (#864) ([c969186f2b66bde1df5e25bbedc5868e27d136f9](https://github.com/googleapis/google-cloud-python/commit/c969186f2b66bde1df5e25bbedc5868e27d136f9))
+
+
+### Bug Fixes
+
+* flaky tests due to imprecision in floating point calculation and performance test setup (#865) ([93404080f853699b9217e4b76391a13525db4e3e](https://github.com/googleapis/google-cloud-python/commit/93404080f853699b9217e4b76391a13525db4e3e))
+* remove call to importlib.metadata.packages_distributions() for py38/py39 (#859) ([628003e217d9a881d24f3316aecfd48c244a73f0](https://github.com/googleapis/google-cloud-python/commit/628003e217d9a881d24f3316aecfd48c244a73f0))
+* Log version check errors (#858) ([6493118cae2720696c3d0097274edfd7fe2bce67](https://github.com/googleapis/google-cloud-python/commit/6493118cae2720696c3d0097274edfd7fe2bce67))
+* closes tailing streams in bidi classes. (#851) ([c97b3a004044ebf8b35c2a7ba97409d7795e11b0](https://github.com/googleapis/google-cloud-python/commit/c97b3a004044ebf8b35c2a7ba97409d7795e11b0))
+
 ## [2.28.1](https://github.com/googleapis/python-api-core/compare/v2.28.0...v2.28.1) (2025-10-28)
 
 

--- a/google/api_core/version.py
+++ b/google/api_core/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.28.1"
+__version__ = "2.29.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.1
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>google-api-core: 2.29.0</summary>

## [2.29.0](https://github.com/googleapis/python-api-core/compare/v2.28.1...v2.29.0) (2026-01-08)

### Features

* make parse_version_to_tuple public (#864) ([c969186f](https://github.com/googleapis/python-api-core/commit/c969186f))

* Auto enable mTLS when supported certificates are detected (#869) ([f8bf6f96](https://github.com/googleapis/python-api-core/commit/f8bf6f96))

### Bug Fixes

* remove call to importlib.metadata.packages_distributions() for py38/py39 (#859) ([628003e2](https://github.com/googleapis/python-api-core/commit/628003e2))

* Log version check errors (#858) ([6493118c](https://github.com/googleapis/python-api-core/commit/6493118c))

* flaky tests due to imprecision in floating point calculation and performance test setup (#865) ([93404080](https://github.com/googleapis/python-api-core/commit/93404080))

* closes tailing streams in bidi classes. (#851) ([c97b3a00](https://github.com/googleapis/python-api-core/commit/c97b3a00))

</details>