### PR TITLE
chore: fix mypy check

### DIFF
--- a/google/api_core/operations_v1/transports/base.py
+++ b/google/api_core/operations_v1/transports/base.py
@@ -119,8 +119,6 @@ class OperationsTransport(abc.ABC):
             host += ":443"  # pragma: NO COVER
         self._host = host
 
-        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
-
         # Save the scopes.
         self._scopes = scopes
 
@@ -133,12 +131,17 @@ class OperationsTransport(abc.ABC):
 
         if credentials_file is not None:
             credentials, _ = google.auth.load_credentials_from_file(
-                credentials_file, **scopes_kwargs, quota_project_id=quota_project_id
+                credentials_file,
+                scopes=scopes,
+                quota_project_id=quota_project_id,
+                default_scopes=self.AUTH_SCOPES,
             )
 
         elif credentials is None:
             credentials, _ = google.auth.default(
-                **scopes_kwargs, quota_project_id=quota_project_id
+                scopes=scopes,
+                quota_project_id=quota_project_id,
+                default_scopes=self.AUTH_SCOPES,
             )
 
         # If the credentials are service account credentials, then always try to use self signed JWT.

--- a/noxfile.py
+++ b/noxfile.py
@@ -276,7 +276,6 @@ def mypy(session):
         "types-requests",
         "types-protobuf",
         "types-dataclasses",
-        "types-mock; python_version=='3.7'",
     )
     session.run("mypy", "google", "tests")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ version = { attr = "google.api_core.version.__version__" }
 include = ["google*"]
 
 [tool.mypy]
-python_version = "3.7"
+python_version = "3.14"
 namespace_packages = true
 ignore_missing_imports = true
 


### PR DESCRIPTION
Mypy tests are are currently failing, due to a combination of a typing change in the auth library, and the deprecation of Python 3.7

This PR fixes mypy, and makes the types a bit more explicit
