### PR TITLE
test: remove nox.options.sessions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -33,21 +33,6 @@ PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 DEFAULT_PYTHON_VERSION = "3.14"
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
-# 'docfx' is excluded since it only needs to run in 'docs-presubmit'
-nox.options.sessions = [
-    "unit",
-    "unit_grpc_gcp",
-    "unit_wo_grpc",
-    "unit_w_prerelease_deps",
-    "unit_w_async_rest_extra",
-    "cover",
-    "mypy",
-    "lint",
-    "lint_setup_py",
-    "blacken",
-    "docs",
-]
-
 # Error if a python version is missing
 nox.options.error_on_missing_interpreters = True
 


### PR DESCRIPTION
This fix removes the `nox.options.sessions` that were left in the noxfile when those sessions were removed in #873.